### PR TITLE
 Prevent rendering a zero at noon with 12 hour time

### DIFF
--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -315,8 +315,13 @@ export function clock(
 			function numerical(date: Date) {
 				const fixunits = (val: number) => (val < 10 ? '0' : '') + val.toString()
 
-				let h = clock.ampm ? date.getHours() % 12 : date.getHours(),
-					m = fixunits(date.getMinutes()),
+				let h = date.getHours()
+
+				if (clock.ampm) {
+					h = h === 12 ? h : h % 12
+				}
+
+				let m = fixunits(date.getMinutes()),
 					s = fixunits(date.getSeconds())
 
 				const domclock = $('clock')

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -315,14 +315,13 @@ export function clock(
 			function numerical(date: Date) {
 				const fixunits = (val: number) => (val < 10 ? '0' : '') + val.toString()
 
-				let h = date.getHours()
-
-				if (clock.ampm) {
-					h = h === 12 ? h : h % 12
-				}
-
-				let m = fixunits(date.getMinutes()),
+				let h = clock.ampm ? date.getHours() % 12 : date.getHours()
+					m = fixunits(date.getMinutes()),
 					s = fixunits(date.getSeconds())
+				
+				if (clock.ampm && h === 0) {
+					h = 12
+				}
 
 				const domclock = $('clock')
 

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -315,10 +315,10 @@ export function clock(
 			function numerical(date: Date) {
 				const fixunits = (val: number) => (val < 10 ? '0' : '') + val.toString()
 
-				let h = clock.ampm ? date.getHours() % 12 : date.getHours()
+				let h = clock.ampm ? date.getHours() % 12 : date.getHours(),
 					m = fixunits(date.getMinutes()),
 					s = fixunits(date.getSeconds())
-				
+
 				if (clock.ampm && h === 0) {
 					h = 12
 				}


### PR DESCRIPTION
When using 12 hour time, noon will currently display as 0:mm

Thanks for your work on this!

Update: Bug is present at midnight as well, updated PR