### PR TITLE
Some changes to the CSS editor

### DIFF
--- a/src/scripts/features/css.ts
+++ b/src/scripts/features/css.ts
@@ -28,10 +28,15 @@ export default function customCss(init?: string, event?: { styling: string }) {
 			lineNumbers: false,
 			wordWrap: true,
 			insertSpaces: false,
-			value: init || `/* ${tradThis('Type in your custom CSS')} */`,
+			value: init || '',
 		}
 
 		const editor = create(options)
+
+		editor.textarea.id = 'css-editor-textarea'
+		editor.textarea.setAttribute('maxlength', '8080')
+		editor.textarea.setAttribute('aria-labelledby', 'lbl-css')
+		editor.textarea.setAttribute('placeholder', tradThis('Type in your custom CSS'))
 
 		editor.addListener('update', (value) => {
 			value = stringMaxSize(value, 8080)

--- a/src/scripts/features/css.ts
+++ b/src/scripts/features/css.ts
@@ -21,25 +21,22 @@ export default function customCss(init?: string, event?: { styling: string }) {
 	}
 
 	onSettingsLoad(async () => {
-		const { defaultCommands, setIgnoreTab } = await import('prism-code-editor/commands')
-		const { createEditor } = await import('prism-code-editor')
-		await import('prism-code-editor/prism/languages/css-extras')
+		const { create } = await import('./csseditor')
 
 		const options = {
 			language: 'css',
 			lineNumbers: false,
 			wordWrap: true,
+			insertSpaces: false,
 			value: init || `/* ${tradThis('Type in your custom CSS')} */`,
 		}
 
-		const editor = createEditor('#css-editor', options, defaultCommands())
+		const editor = create(options)
 
 		editor.addListener('update', (value) => {
 			value = stringMaxSize(value, 8080)
 			eventDebounce({ css: value })
 			stylelink.textContent = value
 		})
-
-		setIgnoreTab(true)
 	})
 }

--- a/src/scripts/features/css.ts
+++ b/src/scripts/features/css.ts
@@ -32,16 +32,22 @@ export default function customCss(init?: string, event?: { styling: string }) {
 		}
 
 		const editor = create(options)
+		const tabCommand = editor.keyCommandMap.Tab
 
 		editor.textarea.id = 'css-editor-textarea'
-		editor.textarea.setAttribute('maxlength', '8080')
+		editor.textarea.maxLength = 8080
 		editor.textarea.setAttribute('aria-labelledby', 'lbl-css')
-		editor.textarea.setAttribute('placeholder', tradThis('Type in your custom CSS'))
+		editor.textarea.placeholder = tradThis('Type in your custom CSS')
 
 		editor.addListener('update', (value) => {
 			value = stringMaxSize(value, 8080)
 			eventDebounce({ css: value })
 			stylelink.textContent = value
 		})
+
+		editor.keyCommandMap.Tab = (e, selection, value) => {
+			if (document.body.matches('.tabbing')) return false
+			return tabCommand?.(e, selection, value)
+		}
 	})
 }

--- a/src/scripts/features/csseditor.ts
+++ b/src/scripts/features/csseditor.ts
@@ -1,0 +1,10 @@
+import { EditorOptions, createEditor } from 'prism-code-editor'
+import { defaultCommands, setIgnoreTab } from 'prism-code-editor/commands'
+import 'prism-code-editor/prism/languages/css-extras'
+import 'prism-code-editor/languages/css'
+
+export const create = (options: EditorOptions) => {
+	return createEditor('#css-editor', options, defaultCommands())
+}
+
+setIgnoreTab(true)

--- a/src/scripts/features/csseditor.ts
+++ b/src/scripts/features/csseditor.ts
@@ -1,10 +1,8 @@
 import { EditorOptions, createEditor } from 'prism-code-editor'
-import { defaultCommands, setIgnoreTab } from 'prism-code-editor/commands'
+import { defaultCommands } from 'prism-code-editor/commands'
 import 'prism-code-editor/prism/languages/css-extras'
 import 'prism-code-editor/languages/css'
 
 export const create = (options: EditorOptions) => {
 	return createEditor('#css-editor', options, defaultCommands())
 }
-
-setIgnoreTab(true)

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -706,7 +706,7 @@ function translatePlaceholders() {
 		['i_tabtitle', 'New tab'],
 		['i_sbrequest', 'Search query: %s'],
 		['i_sbplaceholder', 'Search'],
-		['cssEditor', 'Type in your custom CSS'],
+		['css-editor-textarea', 'Type in your custom CSS'],
 		['i_importtext', 'or paste as text'],
 		['i_addlink-title', 'Title'],
 		['i_addlink-url', 'example.com'],

--- a/src/styles/_global.css
+++ b/src/styles/_global.css
@@ -145,6 +145,7 @@ body button {
 body.tabbing a:focus,
 body.tabbing input:focus,
 body.tabbing textarea:focus,
+body.tabbing .pce-focus,
 body.tabbing select:focus,
 body.tabbing button:focus,
 body.tabbing button:focus,

--- a/src/styles/features/csseditor.css
+++ b/src/styles/features/csseditor.css
@@ -50,9 +50,11 @@
 .pce-no-selection textarea:focus {
 	z-index: 1;
 }
+.pce-line {
+	position: relative;
+}
 .pce-overlays,
 div.pce-overlays > * {
-	content: '';
 	position: absolute;
 	top: 0;
 	right: 0;

--- a/src/styles/features/csseditor.css
+++ b/src/styles/features/csseditor.css
@@ -16,8 +16,7 @@
 	--_pse: var(--padding-inline, 0.75em);
 	--_ns: var(--number-spacing, 0.75em);
 	padding: 16px 20px;
-	tab-size: 1.5em;
-	border: none;
+	outline-offset: -2px;
 	border-radius: 10px;
 	box-sizing: border-box;
 	background: var(--color-param);
@@ -42,31 +41,14 @@
 	height: 100%;
 	width: 100%;
 	color: #0000;
-	padding: 0;
 	overflow: hidden;
-	border-radius: 8px;
-	box-sizing: border-box;
+	outline: none !important;
 	pointer-events: auto;
 	user-select: auto;
 	-webkit-user-select: auto;
 }
 .pce-no-selection textarea:focus {
 	z-index: 1;
-}
-.pce-line {
-	padding: 0;
-	margin: 0;
-	position: relative;
-}
-.pce-line:before {
-	position: sticky;
-	height: 100%;
-	z-index: 2;
-	left: 0;
-	width: var(--padding-left);
-}
-.pce-wrap .pce-line:before {
-	position: absolute;
 }
 .pce-overlays,
 div.pce-overlays > * {

--- a/src/styles/features/csseditor.css
+++ b/src/styles/features/csseditor.css
@@ -78,10 +78,8 @@ div.pce-overlays > * {
  */
 
 aside .pce-wrapper {
-	--selection-bg: #036dd626;
 	--caret: #ffaa33;
 	--selector: #22a4e6;
-	--property: #55b4d4;
 	--string: #86b300;
 	--keyword: #fa8d3e;
 	--operators: #ed9366;
@@ -89,23 +87,27 @@ aside .pce-wrapper {
 
 [data-theme='dark'] aside .pce-wrapper {
 	color-scheme: dark;
+	--selection-bg: #3198ff26;
 	--comment: #888b90bb;
-	--variable: #ddd;
-	--plaintext: #ddd;
+	--variable: #dddddd;
+	--plaintext: #dddddd;
+	--propery: #3ba9ce;
 	--number: #d2a6ff;
 	--color: #98e7cc;
-	--class: #ffc35c;
+	--class: #ee9611;
 	--symbol: #ffaa33;
 }
 
 [data-theme='light'] aside .pce-wrapper {
 	color-scheme: light;
+	--selection-bg: #036dd626;
 	--comment: #787b8099;
 	--plaintext: #5c6166;
 	--variable: #5c6166;
+	--property: #2fafda;
 	--number: #a37acc;
-	--color: #4cbf99;
-	--class: #f2ae49;
+	--color: #41b48e;
+	--class: #e6900f;
 	--symbol: #fa8d3e;
 }
 

--- a/src/styles/features/csseditor.css
+++ b/src/styles/features/csseditor.css
@@ -96,7 +96,7 @@ aside .pce-wrapper {
 	--propery: #3ba9ce;
 	--number: #d2a6ff;
 	--color: #98e7cc;
-	--class: #ee9611;
+	--class: #ffc35c;
 	--symbol: #ffaa33;
 }
 


### PR DESCRIPTION
### What I've changed

Currently, before creating the editor, multiple modules are dynamically imported one by one. Since the build system doesn't create a JS file for each dynamically imported module, there won't be any network waterfalls, but it's still not great for tree-shaking. For example the `editHistory` extension is in the current JS bundle despite being unused. Therefore, I moved the creation of the editor to its own module. This ensures only what's used ends up the final bundle, and it will make it easier to add more extensions to the editor in the future.

I added comment toggling and auto-indent to CSS for the editor. Since the [CSS snippets](https://bonjourr.fr/docs/styles/) all use tabs for indentation, I set the `insertSpaces` option to false.

Next, I moved the focus border for the editor from its textarea to its container. This allowed me to remove the border radius for the textarea. This border radius was clipping the textarea's cursor and selection background, which looked weird. I unfortunitely had to use `!important` to remove the outline since the `body.tabbing textarea:focus` selector has higher specificity. I also added a negative outline offset to the editor container so the outline isn't clipped by the dropdown element with `overflow: hidden`. You could alternatively add `overflow: visible` to `.all .as_css`, but I think the negative outline offset looks good too.

### Other

I've seen that the old CSS editor without syntax highlighting had attributes like `maxlength`, `placeholder` and `aria-labelledby` on the textarea. You can easily add these to the current editor's textarea and they'll all work as expected.

Regarding the themes, I like the dark one, although I think the selection background should be way less transparent. However, some of the tokens in the light theme have pretty terrible contrast, `--class` especially.

Let me know if there's any changes you'd like.