### PR TITLE
Ability to set custom quotes source

### DIFF
--- a/src/scripts/features/quotes.ts
+++ b/src/scripts/features/quotes.ts
@@ -1,4 +1,4 @@
-import { apiFetch, freqControl, isEvery } from '../utils'
+import { apiFetch, equalsCaseInsensitive, freqControl, isEvery } from '../utils'
 import { displayInterface } from '../index'
 import networkForm from '../utils/networkform'
 import storage from '../storage'
@@ -17,10 +17,14 @@ type QuotesUpdate = {
 	refresh?: true
 	type?: string
 	userlist?: string
+	url?: string
 	frequency?: string
 }
 
+type UrlApiResponseType = 'json' | 'csv'
+
 const quotesTypeForm = networkForm('f_qttype')
+const quotesUrlForm = networkForm('f_qturl')
 
 export default async function quotes(init?: QuotesInit, update?: QuotesUpdate) {
 	if (update) {
@@ -47,7 +51,7 @@ export default async function quotes(init?: QuotesInit, update?: QuotesUpdate) {
 		const noCache = !list || list?.length === 0
 
 		if (noCache) {
-			list = await newQuoteFromAPI(lang, quotes.type)
+			list = await tryFetchQuotes(lang, quotes.type, quotes.url)
 			quote = list[0]
 			storage.local.set({ quotesCache: list })
 		}
@@ -55,7 +59,7 @@ export default async function quotes(init?: QuotesInit, update?: QuotesUpdate) {
 
 	if (needsNewQuote) {
 		quotes.last = freqControl.set()
-		quote = controlCacheList(list, lang, quotes.type)
+		quote = controlCacheList(list, lang, quotes.type, quotes.url)
 		storage.sync.set({ quotes })
 	}
 
@@ -71,7 +75,7 @@ export default async function quotes(init?: QuotesInit, update?: QuotesUpdate) {
 // ─── UPDATE
 //
 
-async function updateQuotes({ author, frequency, type, userlist, refresh }: QuotesUpdate) {
+async function updateQuotes({ author, frequency, type, userlist, url, refresh }: QuotesUpdate) {
 	const data = await storage.sync.get(['lang', 'quotes'])
 	const local = await storage.local.get('quotesCache')
 
@@ -82,6 +86,13 @@ async function updateQuotes({ author, frequency, type, userlist, refresh }: Quot
 
 	if (userlist) {
 		data.quotes.userlist = handleUserListChange(userlist)
+	}
+
+	let updateData = false;
+
+	if (canStoreUrl(url)) {
+		data.quotes.url = url
+		updateData = true
 	}
 
 	if (refresh) {
@@ -95,14 +106,18 @@ async function updateQuotes({ author, frequency, type, userlist, refresh }: Quot
 
 	if (isQuotesType(type)) {
 		data.quotes.type = type
-		updateQuotesType(data, type)
+		updateData = true
+	}
+
+	if (updateData) {
+		updateQuotesData(data)
 	}
 
 	storage.sync.set({ quotes: data.quotes })
 }
 
-async function updateQuotesType(data: Sync.Storage, type: Quotes.Sync['type']) {
-	const isUser = type === 'user'
+async function updateQuotesData(data: Sync.Storage) {
+	const isUser = data.quotes.type === 'user'
 	let list: Quote[] = []
 	let selection = 0
 
@@ -113,9 +128,18 @@ async function updateQuotesType(data: Sync.Storage, type: Quotes.Sync['type']) {
 	}
 
 	if (!isUser) {
-		quotesTypeForm.load()
+		const form = data.quotes.type === 'url' ? quotesUrlForm : quotesTypeForm
 
-		list = await newQuoteFromAPI(data.lang, type)
+		try {
+			form.load()
+			list = await fetchQuotes(data.lang, data.quotes.type, data.quotes.url)
+			form.accept()
+		}
+		catch (error) {
+			form.warn("Fetch failed, please check console for further information")
+			console.warn(error)
+		}
+
 		storage.local.set({ quotesCache: list })
 	}
 
@@ -124,7 +148,7 @@ async function updateQuotesType(data: Sync.Storage, type: Quotes.Sync['type']) {
 	}
 
 	document.getElementById('quotes_userlist')?.classList.toggle('shown', isUser)
-	quotesTypeForm.accept()
+	document.getElementById('quotes_url')?.classList.toggle('shown', data.quotes.type === 'url')
 }
 
 function handleUserListChange(input: string): string | undefined {
@@ -159,34 +183,72 @@ function refreshQuotes(data: Sync.Storage, list: Local.Storage['quotesCache'] = 
 		list = csvUserInputToQuotes(data.quotes.userlist)
 	}
 
-	insertToDom(controlCacheList(list, data.lang, data.quotes.type))
+	insertToDom(controlCacheList(list, data.lang, data.quotes.type, data.quotes.url))
 }
 
 //
 // ─── API / STORAGE
 //
 
-async function newQuoteFromAPI(lang: string, type: Quotes.Sync['type']): Promise<Quote[]> {
-	try {
-		if (!navigator.onLine || type === 'user') {
+async function fetchQuotes(lang: string, type: Quotes.Sync['type'], url: string | undefined): Promise<Quote[]> {
+	if (!navigator.onLine || type === 'user') {
+		return []
+	}
+
+	let response: Response | undefined;
+
+	if (type === 'url') {
+		if (!url) {
 			return []
 		}
 
-		const query = (type += type === 'classic' ? `/${lang}` : '')
-		const response = await apiFetch('/quotes/' + query)
-		const json = await response?.json()
+		response = await fetch(url);
+		validateResponse(response);
 
-		if (response?.ok) {
-			return json
+		const responseType = determineUrlApiResponseType(response);
+
+		switch (responseType) {
+			case 'json':
+				return await response.json()
+			case 'csv':
+				const csv = await response.text()
+				return csvToQuotes(csv);
+			default:
+				return []
 		}
-	} catch (error) {
+	}
+	else {
+		const query = `/quotes/${type}` + (type === 'classic' ? `/${lang}` : '')
+
+		response = await apiFetch(query)
+		validateResponse(response);
+
+		return await response.json()
+	}
+}
+
+function validateResponse(response: Response | undefined): asserts response is Response {
+	if (!response) {
+		throw new Error("No response")
+	}
+
+	if (!response.ok) {
+		throw new Error(`Response not ok: ${response.status} ${response.statusText}`)
+	}
+}
+
+async function tryFetchQuotes(lang: string, type: Quotes.Sync['type'], url: string | undefined): Promise<Quote[]> {
+	try {
+		return await fetchQuotes(lang, type, url);
+	}
+	catch (error) {
 		console.warn(error)
 	}
 
 	return []
 }
 
-function controlCacheList(list: Quote[], lang: string, type: Quotes.Sync['type']): Quote {
+function controlCacheList(list: Quote[], lang: string, type: Quotes.Sync['type'], url: Quotes.Sync['url']): Quote {
 	//
 	if (type === 'user') {
 		const randIndex = Math.round(Math.random() * (list.length - 1))
@@ -200,7 +262,7 @@ function controlCacheList(list: Quote[], lang: string, type: Quotes.Sync['type']
 	}
 
 	if (list.length < 2) {
-		newQuoteFromAPI(lang, type).then((list) => {
+		tryFetchQuotes(lang, type, url).then((list) => {
 			storage.local.set({ quotesCache: list })
 		})
 	}
@@ -233,29 +295,66 @@ function insertToDom(quote?: Quote) {
 //
 
 function csvUserInputToQuotes(csv?: string | Quotes.UserInput): Quote[] {
+	if (!csv) {
+		return [];
+	}
+
 	// convert <1.19.0 json format to csv
 	if (Array.isArray(csv)) {
 		csv = oldJSONToCSV(csv)
 	}
 
-	const rows = csv?.split('\n') ?? []
-	const arr: Quote[] = []
-
-	for (const row of rows) {
-		const [author, ...rest] = row.split(',')
-		const content = rest.join(',').trimStart()
-
-		arr.push({ author, content })
-	}
-
-	return arr
+	return csvToQuotes(csv);
 }
 
 export function oldJSONToCSV(input: Quotes.UserInput): string {
 	return input.map((val) => val.join(',')).join('\n')
 }
 
+function csvToQuotes(csv: string): Quote[] {
+	const rows = csv.split('\n')
+	const quotes: Quote[] = []
+
+	for (const row of rows) {
+		const [author, ...rest] = row.split(',')
+		const content = rest.join(',').trimStart()
+		quotes.push({ author, content })
+	}
+
+	return quotes
+}
+
 function isQuotesType(type = ''): type is Quotes.Types {
-	const types: Quotes.Types[] = ['classic', 'kaamelott', 'inspirobot', 'user']
+	const types: Quotes.Types[] = ['classic', 'kaamelott', 'inspirobot', 'user', 'url']
 	return types.includes(type as Quotes.Types)
+}
+
+const urlRegEx = /^https?:\/\//i;
+
+function canStoreUrl(url: string | undefined) {
+	if (url === undefined)
+		return false;
+
+	return url === "" || urlRegEx.test(url);
+}
+
+function determineUrlApiResponseType(response: Response): UrlApiResponseType {
+	const contentType = response.headers.get('content-type')?.split(';', 2)[0];
+
+	switch (contentType) {
+		case 'application/json':
+			return 'json';
+		case 'text/csv':
+			return 'csv';
+	}
+
+	const url = new URL(response.url);
+	const parts = url.pathname.split('.')
+	const extension = parts[parts.length - 1];
+
+	if (equalsCaseInsensitive(extension, 'json')) {
+		return 'json';
+	}
+
+	return 'csv';
 }

--- a/src/scripts/features/quotes.ts
+++ b/src/scripts/features/quotes.ts
@@ -39,18 +39,18 @@ export default async function quotes(init?: QuotesInit, update?: QuotesUpdate) {
 	let selection = init.local?.userQuoteSelection ?? 0
 	let quote: Quote = list[0]
 
-	const noCache = !list || list?.length === 0
-	const isUser = quotes.type === 'user'
-
-	if (noCache) {
-		list = await newQuoteFromAPI(lang, quotes.type)
-		quote = list[0]
-		storage.local.set({ quotesCache: list })
-	}
-
-	if (isUser) {
+	if (quotes.type === 'user') {
 		list = csvUserInputToQuotes(quotes.userlist)
 		quote = list[selection]
+	}
+	else {
+		const noCache = !list || list?.length === 0
+
+		if (noCache) {
+			list = await newQuoteFromAPI(lang, quotes.type)
+			quote = list[0]
+			storage.local.set({ quotesCache: list })
+		}
 	}
 
 	if (needsNewQuote) {

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -123,6 +123,7 @@ function initOptionsValues(data: Sync.Storage) {
 	setInput('i_qtfreq', data.quotes?.frequency || 'day')
 	setInput('i_qttype', data.quotes?.type || 'classic')
 	setInput('i_qtlist', userQuotes ?? '')
+	setInput('i_qturl', data.quotes?.url ?? '')
 	setInput('i_clockface', data.clock?.face || 'none')
 	setInput('i_clockstyle', data.clock?.style || 'round')
 	setInput('i_clocksize', data.clock?.size ?? 5)
@@ -224,6 +225,7 @@ function initOptionsValues(data: Sync.Storage) {
 	// Quotes option display
 	paramId('quotes_options')?.classList.toggle('shown', data.quotes?.on)
 	paramId('quotes_userlist')?.classList.toggle('shown', data.quotes?.type === 'user')
+	paramId('quotes_url')?.classList.toggle('shown', data.quotes?.type === 'url')
 
 	document.querySelectorAll<HTMLFormElement>('#settings form').forEach((form) => {
 		form.querySelectorAll<HTMLInputElement>('input').forEach((input) => {
@@ -541,6 +543,12 @@ function initOptionsEvents() {
 
 	paramId('i_qtlist').addEventListener('change', function () {
 		quotes(undefined, { userlist: this.value })
+	})
+
+	paramId('f_qturl').addEventListener('submit', function (this, event: SubmitEvent) {
+		event.preventDefault()
+
+		quotes(undefined, { url: paramId('i_qturl').value })
 	})
 
 	// Custom fonts

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -179,3 +179,7 @@ function componentToHex(c: number): string {
 	let hex = c.toString(16)
 	return hex.length == 1 ? '0' + hex : hex
 }
+
+export function equalsCaseInsensitive(a: string, b: string) {
+	return a.localeCompare(b, undefined, { sensitivity: 'accent' }) === 0
+}

--- a/src/scripts/utils/networkform.ts
+++ b/src/scripts/utils/networkform.ts
@@ -27,6 +27,7 @@ export default function networkForm(targetId: string) {
 		form?.addEventListener('input', () => {
 			if (form.classList.contains('warn')) {
 				form.classList.remove('warn')
+				button.title = ''
 			}
 		})
 	})

--- a/src/settings.html
+++ b/src/settings.html
@@ -975,6 +975,7 @@
 						<option value="inspirobot">Inspirobot</option>
 						<option value="kaamelott">Kaamelott</option>
 						<option value="user" class="trn">Custom</option>
+						<option value="url">URL</option>
 					</select>
 					<button type="submit">
 						<i></i>
@@ -994,6 +995,33 @@
 						placeholder="Author, Your quote.&#10;Author, Your second quote."
 						maxlength="8000"
 					></textarea>
+				</div>
+			</div>
+
+			<div id="quotes_url" class="dropdown">
+				<hr />
+
+				<div class="wrapper">
+					<label for="i_qturl">URL</label>
+
+					<form id="f_qturl" class="network-form">
+						<input
+							id="i_qturl"
+							type="url"
+							name="qturl"
+							minlength="3"
+							maxlength="512"
+							placeholder="https://example.com/quotes.csv"
+							autocomplete="off"
+							autocorrect="off"
+							autocapitalize="off"
+							spellcheck="false"
+						/>
+						<button type="submit">
+							<i></i>
+							<span>✓</span>
+						</button>
+					</form>
 				</div>
 			</div>
 

--- a/src/styles/_settings.css
+++ b/src/styles/_settings.css
@@ -416,7 +416,8 @@ aside form.valid button:not(:disabled):active {
 }
 
 #analog_options.shown,
-#unsplash_options.shown {
+#unsplash_options.shown,
+#quotes_url.shown {
 	max-height: 110px;
 }
 

--- a/src/types/quotes.ts
+++ b/src/types/quotes.ts
@@ -4,7 +4,7 @@ declare namespace Quotes {
 		content: string
 	}
 
-	type Types = 'classic' | 'kaamelott' | 'inspirobot' | 'user'
+	type Types = 'classic' | 'kaamelott' | 'inspirobot' | 'user' | 'url'
 
 	type Sync = {
 		on: boolean
@@ -13,6 +13,7 @@ declare namespace Quotes {
 		type: Types
 		frequency: Frequency
 		userlist?: string
+		url?: string
 	}
 
 	type UserInput = [string, string][]


### PR DESCRIPTION
I have implemented #373 with the ability to specify both CSV and JSON urls. The response type will be determined by looking at the responses `content-type` header-value and if this doesn't result in json or csv the extension will be checked against `json`. If this also doesn't work we will just assume its a csv response. The json must be in the same format as the official Bonjourr apis.

The feature can be tested with the following api urls:

- https://run.mocky.io/v3/6dc48fd9-dba6-4502-b983-ba5d03688adc
- https://api.quotable.io/quotes/random?limit=20

Quotable serves it's api with all necessary fields Bonjourr expects.

I couldn't get the `translate` script to work so I didn't try how to translate the message that's being passed to the network forms `warn` method. Maybe you can guide me there?