### PR TITLE
Fix Hungarian translation

### DIFF
--- a/_locales/hu/translations.json
+++ b/_locales/hu/translations.json
@@ -16,7 +16,7 @@
 	"with a high of <temp1>° tomorrow": "maximum <temp1>° holnap",
 	"Default group": "Alapértelmezett csoport",
 	"Folder": "Mappa",
-	"Photo by <name>": "Fotó: <név>",
+	"Photo by <name>": "Fotó: <name>",
 	"Editing": "Szerkesztés",
 	"No selection": "Nincs kiválasztás",
 	"Grid position": "Rács pozíciója",


### PR DESCRIPTION
In the current version the placeholder for the name got translated too, making it not displaying properly:

![image](https://github.com/user-attachments/assets/49c824e0-0dbc-4af5-a886-a7614188edbc)

This pull request fixes that.