### PR TITLE
Improve text input handling

### DIFF
--- a/src/scripts/features/backgrounds/unsplash.ts
+++ b/src/scripts/features/backgrounds/unsplash.ts
@@ -20,7 +20,7 @@ type UnsplashUpdate = {
 const collectionForm = networkForm('f_collection')
 
 // https://unsplash.com/@bonjourr/collections
-const bonjourrCollections = {
+export const bonjourrCollections = {
 	noon: 'GD4aOSg4yQE',
 	day: 'o8uX55RbBPs',
 	evening: '3M2rKTckZaQ',
@@ -80,7 +80,7 @@ async function updateUnsplash({ refresh, every, collection }: UnsplashUpdate) {
 		unsplash.lastCollec = 'day'
 
 		unsplashBackgrounds({ unsplash, cache: unsplashCache })
-		collectionForm.accept('i_collection', '2nVzlQADDIE')
+		collectionForm.accept('i_collection', bonjourrCollections[unsplash.lastCollec])
 	}
 
 	if (collection !== undefined && collection.length > 0) {

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -9,7 +9,7 @@ import hideElements from './features/hide'
 import moveElements from './features/move'
 import interfacePopup from './features/popup'
 import localBackgrounds from './features/backgrounds/local'
-import unsplashBackgrounds from './features/backgrounds/unsplash'
+import unsplashBackgrounds, { bonjourrCollections } from './features/backgrounds/unsplash'
 import storage, { getSyncDefaults } from './storage'
 import customFont, { fontIsAvailableInSubset } from './features/fonts'
 import { backgroundFilter, updateBackgroundOption } from './features/backgrounds'
@@ -237,11 +237,9 @@ function initOptionsValues(data: Sync.Storage) {
 	paramId('local_options')?.classList.toggle('shown', data.background_type === 'local')
 	paramId('unsplash_options')?.classList.toggle('shown', data.background_type === 'unsplash')
 
-	// Unsplash collection placeholder
-	if (data?.unsplash?.collection) {
-		const coll = data?.unsplash?.collection
-		paramId('i_collection')?.setAttribute('placeholder', coll ? coll : '2nVzlQADDIE')
-	}
+	// Unsplash collection
+	paramId('i_collection')?.setAttribute('value', data?.unsplash?.collection ?? '')
+	paramId('i_collection')?.setAttribute('placeholder', data?.unsplash?.collection || bonjourrCollections[data?.unsplash?.lastCollec ?? 'day'])
 
 	// Quotes option display
 	paramId('quotes_options')?.classList.toggle('shown', data.quotes?.on)

--- a/src/scripts/utils/networkform.ts
+++ b/src/scripts/utils/networkform.ts
@@ -17,10 +17,8 @@ export default function networkForm(targetId: string) {
 		button = form?.querySelector('button:last-of-type') as HTMLButtonElement
 
 		form.querySelectorAll('input').forEach((input) => {
-			input?.addEventListener('blur', () => {
-				if (input.value === '') {
-					form.classList.remove('valid')
-				}
+			input?.addEventListener('input', () => {
+				form.classList.toggle('valid', form.checkValidity() && input.value !== input.getAttribute('value'))
 			})
 		})
 
@@ -54,10 +52,12 @@ export default function networkForm(targetId: string) {
 	}
 
 	function accept(inputId?: string, value?: string) {
-		if (inputId && value) {
+		if (inputId && form.checkValidity()) {
 			form.classList.remove('valid')
-			form.querySelectorAll('input').forEach((input) => (input.value = ''))
-			document.getElementById(inputId)?.setAttribute('placeholder', value)
+
+			let input = document.getElementById(inputId)
+			input.setAttribute('value', input.value)
+			input.setAttribute('placeholder', value)
 		}
 
 		setTimeout(() => resetForm(), 200)

--- a/src/settings.html
+++ b/src/settings.html
@@ -152,7 +152,7 @@
 						name="collection"
 						id="i_collection"
 						autocomplete="off"
-						placeholder="2nVzlQADDIE"
+						placeholder="o8uX55RbBPs"
 						maxlength="256"
 						spellcheck="false"
 						autocomplete="off"


### PR DESCRIPTION
- Indicate to the user more clearly when the Unsplash collection is actually changed and show the submit button only when needed.
- Allow to reset the collection by leaving the input empty.

Fix #494 