### PR TITLE
Fix unsplash image credits

### DIFF
--- a/src/scripts/features/backgrounds/unsplash.ts
+++ b/src/scripts/features/backgrounds/unsplash.ts
@@ -301,7 +301,7 @@ function imgCredits(image: Unsplash.Image) {
 		// ⚠️ In this order !
 		if (model) exif += `${model} - `
 		if (aperture) exif += `f/${aperture} `
-		if (exposure_time) exif += `${aperture}s `
+		if (exposure_time) exif += `${exposure_time}s `
 		if (iso) exif += `${iso}ISO `
 		if (focal_length) exif += `${focal_length}mm`
 	}


### PR DESCRIPTION
<img width="265" alt="Screenshot 2025-03-16 at 11 45 11 am" src="https://github.com/user-attachments/assets/531b6859-875e-4bc7-875a-d179359beb5f" />

exposure time isn't displayed correctly, it wrongly repeats the aperture