### PR TITLE
Enhancement: AM/PM position adjustment 

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -291,12 +291,13 @@
 				<div id="time-container" data-hide="clock">
 					<div id="clock-wrapper" class="clock-wrapper" data-index="0">
 						<h1 class="digital" data-hide="clock">
-							<span class="digital-ampm"
-								><span class="digital-am">am</span><span class="digital-pm">pm</span></span
-							><span class="digital-hh-leading-zero">0</span><span class="digital-hh"></span
+							<span class="digital-hh-leading-zero">0</span><span class="digital-hh"></span
 							><span class="digital-hh-separator">:</span><span class="digital-mm"></span
 							><span class="digital-mm-separator">:</span><span class="digital-ss"></span
 							><span class="digital-number-width">0</span>
+							<span class="digital-ampm">
+								<span class="digital-am">am</span><span class="digital-pm">pm</span>
+							</span>
 						</h1>
 
 						<div class="analog" data-hide="clock">

--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -139,6 +139,7 @@ export const SYNC_DEFAULT: Sync = {
 		analog: false,
 		seconds: false,
 		ampmlabel: false,
+		ampmposition: 'top-left',
 		worldclocks: false,
 		timezone: 'auto',
 	},

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -194,6 +194,7 @@ function initOptionsValues(data: Sync, local: Local) {
 	setCheckbox('i_quotes', data.quotes?.on ?? false)
 	setCheckbox('i_ampm', data.clock?.ampm ?? false)
 	setCheckbox('i_ampm-label', data.clock?.ampmlabel ?? false)
+	setInput('i_ampm_position', data.clock.ampmposition || 'top-left')
 	setCheckbox('i_sbsuggestions', data.searchbar?.suggestions ?? true)
 	setCheckbox('i_sbnewtab', data.searchbar?.newtab ?? false)
 	setCheckbox('i_qtauthor', data.quotes?.author ?? false)
@@ -238,6 +239,7 @@ function initOptionsValues(data: Sync, local: Local) {
 	paramId('greetings_options')?.classList.toggle('shown', !data.hide?.greetings)
 	paramId('digital_options')?.classList.toggle('shown', !data.clock.analog)
 	paramId('ampm_label')?.classList.toggle('shown', data.clock.ampm)
+	paramId('ampm_position')?.classList.toggle('shown', data.clock.ampmlabel)
 	paramId('worldclocks_options')?.classList.toggle('shown', data.clock.worldclocks)
 	paramId('main_options')?.classList.toggle('shown', data.main)
 	paramId('weather_provider')?.classList.toggle('shown', data.weather?.moreinfo === 'custom')
@@ -558,6 +560,13 @@ function initOptionsEvents() {
 
 	onclickdown(paramId('i_ampm-label'), (_, target) => {
 		clock(undefined, { ampmlabel: target.checked })
+
+		// shows/hides ampm_position option
+		paramId('ampm_position')?.classList.toggle('shown', target.checked)
+	})
+
+	paramId('i_ampm_position').addEventListener('change', function (this: HTMLInputElement) {
+		clock(undefined, { ampmposition: this.value })
 	})
 
 	paramId('i_timezone').addEventListener('change', function (this: HTMLInputElement) {

--- a/src/settings.html
+++ b/src/settings.html
@@ -794,6 +794,20 @@
 						<input id="i_ampm-label" class="switch" type="checkbox" />
 					</div>
 				</div>
+
+				<div id="ampm_position" class="dropdown">
+					<hr />
+					
+					<div class="wrapper">
+						<label for="i_ampm_position" class="trn">AM/PM position</label>
+						<select id="i_ampm_position">
+							<option value="top-left" class="trn">Top left</option>
+							<option value="top-right" class="trn">Top right</option>
+							<option value="bottom-left" class="trn">Bottom left</option>
+							<option value="bottom-right" class="trn">Bottom right</option>
+						</select>
+					</div>
+				</div>
 			</div>
 
 			<hr />

--- a/src/styles/features/time.css
+++ b/src/styles/features/time.css
@@ -46,6 +46,11 @@
 	direction: ltr;
 }
 
+.digital[data-ampm-label][data-ampm][data-ampmposition='top-right'],
+.digital[data-ampm-label][data-ampm][data-ampmposition='bottom-right'] {
+	margin-left: var(--seconds-width);
+}
+
 .digital span {
 	text-align: left;
 }
@@ -85,14 +90,38 @@
 	display: none;
 }
 
-[data-ampm-label][data-ampm] .digital-ampm,
-[data-ampm-label][data-ampm='am'] .digital-am,
-[data-ampm-label][data-ampm='pm'] .digital-pm {
+[data-ampm-label][data-ampm][data-ampmposition] .digital-ampm,
+[data-ampm-label][data-ampm='am'][data-ampmposition] .digital-am,
+[data-ampm-label][data-ampm='pm'][data-ampmposition] .digital-pm {
 	display: inline-block;
 }
 
 [data-ampm-label][data-ampm] {
 	margin-inline-end: 0.5em;
+}
+
+#time[class] * * [data-ampm-label][data-ampm][data-ampmposition='top-right'] .digital-ampm,
+#time * * [data-ampm-label][data-ampm][data-ampmposition='top-right'] .digital-ampm {
+	margin-left: calc(var(--seconds-width) * -1/1.5);
+}
+
+#time[class] * * [data-ampm-label][data-ampm][data-ampmposition='bottom-right'] .digital-ampm,
+#time * * [data-ampm-label][data-ampm][data-ampmposition='bottom-right'] .digital-ampm {
+	margin-left: calc(var(--seconds-width) * -1/1.5);
+	vertical-align: bottom;
+}
+
+#time[class='seconds'] * * [data-ampm-label][data-ampm][data-ampmposition='top-right'] .digital-ampm {
+	margin-left: var(--seconds-width)px;
+}
+
+#time[class='seconds'] * * [data-ampm-label][data-ampm][data-ampmposition='bottom-right'] .digital-ampm {
+	margin-left: var(--seconds-width)px;
+	vertical-align: bottom;
+}
+
+[data-ampm-label][data-ampm][data-ampmposition='bottom-left'] .digital-ampm {
+	vertical-align: bottom;
 }
 
 #time.seconds .digital-ss {

--- a/src/styles/settings/dropdowns.css
+++ b/src/styles/settings/dropdowns.css
@@ -61,7 +61,7 @@
 }
 
 #digital_options.shown {
-	max-height: 120px;
+	max-height: 180px;
 }
 
 #analog_options.shown {
@@ -73,6 +73,10 @@
 }
 
 #ampm_label.shown {
+	max-height: 60px;
+}
+
+#ampm_position.shown {
 	max-height: 60px;
 }
 

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -112,6 +112,7 @@ export interface Clock {
 	timezone: string
 	size: number
 	ampmlabel: boolean
+	ampmposition?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
 	worldclocks: boolean
 	face?: 'none' | 'number' | 'roman' | 'marks'
 	style?: 'round' | 'square' | 'transparent'


### PR DESCRIPTION
This is a response to the enhancement idea brought up by @madmaximux (#468) to move the AM/PM indicator to the right of the time. I added a dropdown below the AM/PM toggle allowing a user to adjust the indicator to <ins>4 positions</ins>:

- Top-left (original)
- Top-right
- Bottom-left
- Bottom-right

## This is what the dropdown looks like:

![image](https://github.com/user-attachments/assets/a16f3582-aaf4-4d56-af7a-c03bddaa88fd)
(Dropdown only shows up with AM/PM is toggled <ins>on</ins>)

## Here are all 4 configurations:

![image](https://github.com/user-attachments/assets/6870be5c-2379-4392-99d1-19a4fbe25372)
![image](https://github.com/user-attachments/assets/a831146a-52b6-4cf6-ba94-76e63ee22e4e)
![image](https://github.com/user-attachments/assets/4d9888e3-3b95-45e5-983c-d5aaec98f41f)
![image](https://github.com/user-attachments/assets/751b30e1-f8ae-4f34-ba1b-1d04600b3806)

This is my first time adding an actual feature so if I need to do anything different for my pull request next time please tell me. Also, I tried keeping my syntax similar to everything else, but it might need to be changed. Thank you :)