### PR TITLE
fix: quotes from URL bug

### DIFF
--- a/src/scripts/features/quotes.ts
+++ b/src/scripts/features/quotes.ts
@@ -255,15 +255,14 @@ function controlCacheList(list: Quote[], lang: string, type: Quotes['type'], url
 	}
 
 	if (list.length > 1) {
-		list.shift()
+		const quote = list.shift()
 		storage.local.set({ quotesCache: list })
+		return quote ?? { author: '', content: '' }
 	}
 
-	if (list.length < 2) {
-		tryFetchQuotes(lang, type, url).then((list) => {
-			storage.local.set({ quotesCache: list })
-		})
-	}
+	tryFetchQuotes(lang, type, url).then((list) => {
+		storage.local.set({ quotesCache: list })
+	})
 
 	return list[0]
 }


### PR DESCRIPTION
Fixing bug, when using the URL option, after the end of the quote list, the first quote is always skipped.
![bug](https://github.com/user-attachments/assets/da2fb506-6730-42d6-b56b-5be949d94013)
