### PR TITLE
Fix for gist sync not working on refresh

### DIFF
--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -196,6 +196,7 @@ export const SYNC_DEFAULT: Sync = {
 
 export const LOCAL_DEFAULT: Local = {
 	syncType: PLATFORM === 'online' ? 'off' : 'browser',
+	gistToken: '',
 	userQuoteSelection: 0,
 	translations: undefined,
 	quotesCache: [],


### PR DESCRIPTION
As gistToken was not available on local init the gist sync feature would require the user to re-enter the token on page reload. 
Even if the token was already in localstorage.