### PR TITLE
Changes "Handbuch" to "Manuell" in german locale

### DIFF
--- a/_locales/de/translations.json
+++ b/_locales/de/translations.json
@@ -201,7 +201,7 @@
   "Name": "Name",
   "Weather": "Wetter",
   "Geolocation": "Geolokalisierung",
-  "Manual": "Handbuch",
+  "Manual": "Manuell",
   "Approximate": "Ungefähr",
   "Precise": "Präzise",
   "Location": "Stadtlage",


### PR DESCRIPTION
Looks like a machine translated entry, which got introduced around a year ago - so I thought I quickly fix it. 😊

"Handbuch" is another word for "instruction book" in german - the other meaning that "manual" has. That does not really make sense in the context it used in the settings. Another appropriate translation could be "Händisch", but "Manuell" is already used in "Manueller Standort", so I think it is more streamlined and thus fine. 😊