### PR TITLE
fix: remove will-change: opacity causing black box artifact in Firefox

### DIFF
--- a/src/styles/features/pomodoro.css
+++ b/src/styles/features/pomodoro.css
@@ -8,7 +8,6 @@ body #background-wrapper:after {
     transition: opacity 0.5s ease;
     position: absolute;
     inset: 0;
-    will-change: opacity;
     opacity: 0;
     box-shadow: inset 0px 0px 285px rgba(0, 0, 0, 0.9);
 }


### PR DESCRIPTION
Vignette pseudo-element `body #background-wrapper:after` in `pomodoro.css` had `will-change: opacity` set, which kept Firefox on a permanent GPU compositor layer for it.
  - At `opacity: 0` the large `inset box-shadow` still bled through that invisible layer, eventually showing up as a black line/box artifact
  - Removed `will-change: opacity`
  - `transition: opacity 0.5s ease` handles the vignette fade on its own, no pre-promotion hint needed

  <img width="887" height="1187" alt="bug_screen1" src="https://github.com/user-attachments/assets/1e2d4aaf-bea7-4e05-85e2-51d8a57bb360" />

