### PR TITLE
Broken background URLs after importing JSON file

### DIFF
--- a/src/scripts/features/backgrounds/urls.ts
+++ b/src/scripts/features/backgrounds/urls.ts
@@ -168,17 +168,7 @@ export function toggleUrlsButton(storage: string, value: string): void {
 
 export function applyUrls(backgrounds: Backgrounds): void {
     const editorValue = backgroundUrlsEditor.value
-    const backgroundUrls: Local['backgroundUrls'] = {}
-
-    for (const url of editorValue.split('\n')) {
-        if (url.startsWith('http')) {
-            backgroundUrls[url] = {
-                lastUsed: new Date().toString(),
-                format: formatFromFileExt(url),
-                state: 'NONE',
-            }
-        }
-    }
+    const backgroundUrls = buildBackgroundUrls(parseUrlList(editorValue), 'NONE')
 
     globalUrlValue = backgrounds.urls = editorValue
     storage.local.set({ backgroundUrls })
@@ -186,6 +176,27 @@ export function applyUrls(backgrounds: Backgrounds): void {
 
     toggleUrlsButton('osef', 'osef')
     checkUrlInfos(backgroundUrls)
+}
+
+export function parseUrlList(urls: string): string[] {
+    return urls
+        .split('\n')
+        .map((url) => url.trim())
+        .filter((url) => url.startsWith('http'))
+}
+
+export function buildBackgroundUrls(urls: string[], initialState: BackgroundUrlState = 'OK'): Local['backgroundUrls'] {
+    const backgroundUrls: Local['backgroundUrls'] = {}
+
+    for (const url of urls) {
+        backgroundUrls[url] = {
+            lastUsed: new Date().toString(),
+            format: formatFromFileExt(url),
+            state: initialState,
+        }
+    }
+
+    return backgroundUrls
 }
 
 async function checkUrlInfos(backgroundUrls: Local['backgroundUrls']): Promise<void> {

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -2,6 +2,7 @@ import { darkmode, favicon, pageControl, tabTitle, textShadow } from './features
 import { initSupportersSettingsNotif, supportersNotifications } from './features/supporters.ts'
 import { customFont, fontIsAvailableInSubset, systemfont } from './features/fonts.ts'
 import { backgroundUpdate, initBackgroundOptions, toggleMuteStatus } from './features/backgrounds/index.ts'
+import { parseUrlList, buildBackgroundUrls } from './features/backgrounds/urls.ts'
 import { changeGroupTitle, initGroups } from './features/links/groups.ts'
 import { synchronization } from './features/synchronization/index.ts'
 import { interfacePopup } from './features/popup.ts'
@@ -1484,6 +1485,15 @@ async function importSettings(imported: Partial<Sync>): Promise<void> {
 
         storage.sync.clear()
         storage.sync.set(data)
+
+        if (imported?.backgrounds?.type === 'urls') {
+            const urls = parseUrlList(imported.backgrounds.urls ?? '')
+
+            if (urls.length > 0) {
+                storage.local.set({ backgroundUrls: buildBackgroundUrls(urls) })
+            }
+        }
+
         fadeOut()
     } catch (_) {
         // ...


### PR DESCRIPTION
Fixes #831 

> When importing a JSON file that has URL backgrounds enabled, the backgrounds URLs feature gets stuck. Even after refreshing the page or switching back and forth between background types, the background stays black and the URLs unverified.