### PR TITLE
feat: add search box to filter settings items (#833)

### DIFF
--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -120,6 +120,7 @@ function settingsInitEvent(event: Event): void {
     initOptionsValues(sync, local)
     initOptionsEvents()
     settingsFooter()
+    initSettingsSearch()
 
     // 3. Can be deferred
 
@@ -1607,4 +1608,47 @@ function setFormInput(id: string, defaults: string, value?: string): void {
     } else {
         input.setAttribute('placeholder', defaults)
     }
+}
+
+function initSettingsSearch(): void {
+    const searchInput = document.getElementById('settings-search') as HTMLInputElement | null;
+    if (!searchInput) return;
+
+    searchInput.addEventListener('input', (e: Event) => {
+        const target = e.target as HTMLInputElement;
+        const query = target.value.toLowerCase().trim();
+        
+        // Bonjourr wraps individual settings inside elements with a '.param' class
+        const params = document.querySelectorAll<HTMLElement>('#settings-container .param');
+
+        params.forEach((param) => {
+            const textContent = param.textContent?.toLowerCase() || '';
+
+            if (query === '') {
+                param.style.display = '';
+            } else if (textContent.includes(query)) {
+                param.style.display = '';
+            } else {
+                param.style.display = 'none';
+            }
+        });
+
+        // Hide or show group/section headers if all their nested controls are hidden
+        const categories = document.querySelectorAll<HTMLElement>('#settings-container .category, #settings-container fieldset');
+        categories.forEach((category) => {
+            if (query === '') {
+                category.style.display = '';
+                return;
+            }
+            
+            // Check if this specific group still has any visible parameters left
+            const visibleParams = category.querySelectorAll<HTMLElement>('.param:not([style*="display: none"])');
+            
+            if (visibleParams.length === 0) {
+                category.style.display = 'none';
+            } else {
+                category.style.display = '';
+            }
+        });
+    });
 }

--- a/src/settings.html
+++ b/src/settings.html
@@ -2,6 +2,15 @@
     <div></div>
 </div>
 
+<div id="settings-search-wrapper" style="padding: 10px 20px;">
+    <input 
+        type="text" 
+        id="settings-search" 
+        placeholder="Search settings... (e.g., wallpaper)" 
+        style="width: 100%; padding: 10px; border-radius: 8px; border: 1px solid var(--border-color, #333); background: var(--bg-color, #222); color: #fff; font-size: 14px;"
+    />
+</div>
+
 <div id="supporters-notif-container" class="dropdown">
     <div id="supporters-notif" tabindex="0">
         <button id="supporters-notif-close" tabindex="0">


### PR DESCRIPTION
### Description
Addresses #833 by introducing a dynamic real-time search/filter input at the top of the settings panel. This allows users to quickly find specific configuration options (like "wallpaper", "clock", or "font") without manually scrolling through the extensive options list.

### Changes Made
- **`src/settings.html`**: Inserted a minimalist search input field at the top of the settings panel layout.
- **`src/scripts/settings.ts`**: Implemented client-side filtering logic within `settingsInitEvent()` that:
  - Dynamically shows/hides individual `.param` elements based on case-insensitive matches against user input.
  - Automatically hides empty `.settings-title` sections when none of their nested parameters match the search query.

### Closes
Closes #833