### PR TITLE
Fix for opening folder with keyboard crash

### DIFF
--- a/src/scripts/features/links/folders.ts
+++ b/src/scripts/features/links/folders.ts
@@ -28,7 +28,6 @@ export async function folderClick(event: MouseEvent | KeyboardEvent): Promise<vo
     } else if (event instanceof KeyboardEvent) {
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault() // prevent scrolling when pressing Space
-            folderClick(event)
         } else return
     }
 


### PR DESCRIPTION
Closes #844.

This seems to work/be logical, but also seems too good to be true. Am I missing something @victrme?