### PR TITLE
fix: only redirect searchbar input to URLs with valid TLDs or local hosts

### DIFF
--- a/src/scripts/features/searchbar.ts
+++ b/src/scripts/features/searchbar.ts
@@ -34,6 +34,96 @@ const customEngineForm = networkForm('f_sbrequest')
 
 let socket: WebSocket | undefined
 const domainPattern = /^(?!.*\s)(?:https?:\/\/)?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z0-9-]{2,})/i
+const COMMON_TLDS = new Set([
+    'ac',
+    'ad',
+    'ae',
+    'af',
+    'ag',
+    'ai',
+    'al',
+    'am',
+    'app',
+    'ar',
+    'at',
+    'au',
+    'be',
+    'bg',
+    'biz',
+    'br',
+    'ca',
+    'cc',
+    'ch',
+    'cl',
+    'cloud',
+    'club',
+    'cn',
+    'co',
+    'com',
+    'cz',
+    'de',
+    'dev',
+    'dk',
+    'edu',
+    'ee',
+    'es',
+    'eu',
+    'fi',
+    'fm',
+    'fr',
+    'gg',
+    'gov',
+    'gr',
+    'hk',
+    'hr',
+    'hu',
+    'id',
+    'ie',
+    'il',
+    'in',
+    'info',
+    'io',
+    'is',
+    'it',
+    'jp',
+    'kr',
+    'li',
+    'lt',
+    'lu',
+    'lv',
+    'me',
+    'mil',
+    'mx',
+    'net',
+    'nl',
+    'no',
+    'nz',
+    'online',
+    'org',
+    'pl',
+    'pro',
+    'pt',
+    'ro',
+    'rs',
+    'ru',
+    'se',
+    'sg',
+    'shop',
+    'site',
+    'sk',
+    'space',
+    'store',
+    'tech',
+    'to',
+    'tr',
+    'tv',
+    'tw',
+    'ua',
+    'uk',
+    'us',
+    'vn',
+    'xyz',
+])
 
 const domsuggestions = document.getElementById('sb-suggestions') as HTMLUListElement | undefined
 const domcontainer = document.getElementById('sb_container') as HTMLDivElement | undefined
@@ -168,11 +258,72 @@ async function updateSearchbar({
 //	Search Submission
 //
 
-function isValidUrl(string: string): boolean {
+function cleanHostname(hostname: string): string {
+    return hostname.toLowerCase().replace(/\.$/, '')
+}
+
+function isLocalHostname(hostname: string): boolean {
+    const clean = cleanHostname(hostname)
+
+    if (clean === 'localhost') {
+        return true
+    }
+
+    const parts = clean.split('.')
+    if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) {
+        return false
+    }
+
+    const octets = parts.map(Number)
+    if (octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+        return false
+    }
+
+    const [first, second] = octets
+    return first === 10 ||
+        first === 127 ||
+        (first === 172 && second >= 16 && second <= 31) ||
+        (first === 192 && second === 168)
+}
+
+function getInputHostname(value: string): string {
+    const withoutProtocol = value.replace(/^https?:\/\//i, '')
+    const host = withoutProtocol.split(/[/?#]/)[0]?.split('@').pop() ?? ''
+    const hostname = host.startsWith('[') ? host : host.split(':')[0] ?? ''
+    return cleanHostname(hostname)
+}
+
+function hasCommonTld(hostname: string): boolean {
+    const labels = cleanHostname(hostname).split('.')
+    const tld = labels[labels.length - 1] ?? ''
+    const validLabels = labels.every((label) =>
+        /^[a-z0-9-]+$/.test(label) && !label.startsWith('-') && !label.endsWith('-')
+    )
+    return validLabels && COMMON_TLDS.has(tld)
+}
+
+function hasProtocol(value: string): boolean {
+    return value.startsWith('http://') || value.startsWith('https://')
+}
+
+function createDomainUrl(value: string): string {
+    if (hasProtocol(value)) {
+        return value
+    }
+
+    const secureUrl = `https://${value}`
+
+    return isLocalHostname(getInputHostname(secureUrl)) ? `http://${value}` : secureUrl
+}
+
+export function isValidUrl(string: string, hadProtocol = true): boolean {
     try {
-        const basicURL = !!new URL(string)
+        const url = new URL(string)
+        const basicURL = !!url
         const regexMatch = domainPattern.test(string)
-        return basicURL && regexMatch
+        const localHostname = isLocalHostname(getInputHostname(string))
+        const allowedTld = hadProtocol || hasCommonTld(url.hostname)
+        return basicURL && (localHostname || (regexMatch && allowedTld))
     } catch (_) {
         return false
     }
@@ -238,10 +389,10 @@ function submitSearch(e: Event): void {
 
     engine = engine.replace('default', 'google')
 
-    const hasProtocol = val.startsWith('http://') || val.startsWith('https://')
-    const domainUrl = hasProtocol ? val : `https://${val}`
+    const hadProtocol = hasProtocol(val)
+    const domainUrl = createDomainUrl(val)
     const searchUrl = createSearchUrl(val, engine)
-    const url = isValidUrl(domainUrl) ? domainUrl : searchUrl
+    const url = isValidUrl(domainUrl, hadProtocol) ? domainUrl : searchUrl
     const target = newtab ? '_blank' : '_self'
 
     globalThis.open(url, target)
@@ -445,8 +596,6 @@ function suggestions(results: Suggestions): void {
 
 function handleUserInput(e: Event): void {
     const value = ((e as InputEvent).target as HTMLInputElement).value ?? ''
-    const hasProtocol = value.startsWith('http://') || value.startsWith('https://')
-    const withProtocol = hasProtocol ? value : `https://${value}`
     const startsTypingProtocol = 'https://'.startsWith(value) || 'http://'.startsWith(value)
 
     // Button display toggle
@@ -462,7 +611,7 @@ function handleUserInput(e: Event): void {
         return
     }
 
-    if (startsTypingProtocol || isValidUrl(withProtocol)) {
+    if (startsTypingProtocol || isValidUrl(createDomainUrl(value), hasProtocol(value))) {
         domsuggestions?.classList.remove('shown')
         return
     }

--- a/tests/searchbar.test.ts
+++ b/tests/searchbar.test.ts
@@ -1,0 +1,127 @@
+import './init.test.ts'
+
+// Import script after test init, document needs to be loaded first
+import { isValidUrl } from '../src/scripts/features/searchbar.ts'
+import { assert, assertEquals, assertFalse } from '@std/assert'
+
+type OpenCall = {
+    url: string
+    target?: string
+}
+
+function setSearchbarDom(): void {
+    document.body.innerHTML = `
+        <form id="sb_container">
+            <input id="searchbar" />
+            <div id="sb-buttons"></div>
+            <button id="sb_empty" type="button"></button>
+            <button id="sb_submit" type="submit"></button>
+            <ul id="sb-suggestions"></ul>
+        </form>
+    `
+}
+
+function mockOpen(): { calls: OpenCall[]; restore: () => void } {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'open')
+    const calls: OpenCall[] = []
+
+    Object.defineProperty(globalThis, 'open', {
+        configurable: true,
+        value: (url?: string | URL, target?: string): null => {
+            calls.push({ url: String(url), target })
+            return null
+        },
+    })
+
+    return {
+        calls,
+        restore: () => {
+            if (descriptor) {
+                Object.defineProperty(globalThis, 'open', descriptor)
+            }
+        },
+    }
+}
+
+Deno.test('Searchbar URL validation rejects auto-prepended dotted non-domains', () => {
+    for (
+        const value of [
+            'https://802.11a',
+            'https://802.11,,',
+            'https://nginx.conf',
+            'https://config.yaml',
+            'https://settings.json',
+            '802.11',
+        ]
+    ) {
+        assertFalse(isValidUrl(value, false), `${value} should search`)
+    }
+})
+
+Deno.test('Searchbar URL validation accepts domains and local addresses', () => {
+    for (
+        const value of [
+            'https://example.com',
+            'https://www.gov.za',
+            'https://github.com/foo',
+            'https://sub.example.co.uk',
+            'https://localhost',
+            'https://192.168.1.1',
+            'https://127.0.0.1',
+            'https://10.0.0.1',
+            'https://172.16.0.1',
+            'https://172.31.255.255',
+        ]
+    ) {
+        assert(isValidUrl(value), `${value} should open directly`)
+    }
+})
+
+Deno.test({
+    name: 'Searchbar opens local addresses over http and searches rejected hosts',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+        setSearchbarDom()
+
+        const { searchbar } = await import('../src/scripts/features/searchbar.ts?submit-local')
+        const form = document.getElementById('sb_container') as HTMLFormElement
+        const input = document.getElementById('searchbar') as HTMLInputElement
+        const open = mockOpen()
+
+        try {
+            searchbar({
+                on: true,
+                newtab: false,
+                engine: 'google',
+                request: '',
+                suggestions: false,
+                placeholder: '',
+            })
+
+            for (
+                const [value, expected] of [
+                    ['localhost', 'http://localhost'],
+                    ['192.168.1.1', 'http://192.168.1.1'],
+                    ['127.0.0.1', 'http://127.0.0.1'],
+                ]
+            ) {
+                input.value = value
+                form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+                assertEquals(open.calls.at(-1), { url: expected, target: '_self' })
+            }
+
+            input.value = 'nginx.conf'
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+            assertEquals(open.calls.at(-1), { url: 'https://www.google.com/search?q=nginx.conf', target: '_self' })
+
+            form.setAttribute('data-engine', 'custom')
+            form.setAttribute('data-request', 'https://search.example.com/?q=%s')
+            input.value = 'settings.json'
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+            assertEquals(open.calls.at(-1), { url: 'https://search.example.com/?q=settings.json', target: '_self' })
+        } finally {
+            open.restore()
+        }
+    },
+})


### PR DESCRIPTION
## Summary

Stops the searchbar from opening broken pages when the typed text only looks domain-like. Strings such as `802.11a`, `nginx.conf`, `config.yaml`, `settings.json`, and `802.11,,` now go to the search engine instead of being treated as URLs.

## Why this matters

`isValidUrl()` combined `new URL()` (which accepts almost anything once `https://` is prepended) with a permissive `domainPattern`, so any `word.word` shape was opened as a website. This produced dead redirects for filenames and version numbers, as reported in #843 (and the duplicate #866). The fix follows the approach the owner chose in the thread: only redirect a bare string when its host's TLD is in a whitelist of common top-level domains, while still treating local addresses as URLs.

## Changes

- `isValidUrl()` now requires a bare candidate host to either be a recognized local/private address (`localhost`, `127.0.0.1`, IPv4 loopback, RFC-1918 `10.*` / `172.16-31.*` / `192.168.*`) or end in a TLD from a new curated `COMMON_TLDS` set. A curated subset keeps the bundle small instead of shipping the full IANA list.
- When the user explicitly types an `http://` or `https://` prefix, the TLD whitelist is bypassed so valid but less common TLDs (for example `https://www.gov.za`) still open.
- Local and private addresses are opened over `http://` instead of being force-upgraded to `https://`.
- The bias is toward search (false negatives) over broken redirects (false positives), matching the owner's stated preference.

## Testing

- `deno fmt --check` on the touched files: clean
- `deno task types`: passes
- `deno task test`: 9 passed (20 steps), 0 failed, including new `tests/searchbar.test.ts` covering the rejected filenames, real domains, local addresses opening over `http`, and explicit uncommon-TLD URLs.

Fixes #843

AI was used for assistance.
