### PR TITLE
fix: ignore Firefox bookmark separators when syncing toolbar to Quick links

### DIFF
--- a/src/scripts/features/links/bookmarks.ts
+++ b/src/scripts/features/links/bookmarks.ts
@@ -352,6 +352,10 @@ function bookmarkTreeToFolderList(treenode: Treenode, data: Sync): BookmarksFold
                 continue
             }
 
+            if (isFirefoxSeparator(child)) {
+                continue
+            }
+
             if (!folders[treenode.title]) {
                 folders[treenode.title] = {
                     title: treenode.title,
@@ -393,4 +397,23 @@ function bookmarkTreeToFolderList(treenode: Treenode, data: Sync): BookmarksFold
     }
 
     return Object.values(folders)
+}
+
+function isFirefoxSeparator(bookmark: Treenode): boolean {
+    if (bookmark.title.trim() !== '') {
+        return false
+    }
+
+    const rawUrl = (bookmark.url ?? '').trim()
+
+    if (rawUrl.toLowerCase().startsWith('data:')) {
+        return true
+    }
+
+    try {
+        // Firefox normalizes its `data:` separator placeholder to `https://data/`.
+        return new URL(rawUrl).hostname.toLowerCase() === 'data'
+    } catch (_error) {
+        return false
+    }
 }

--- a/src/scripts/features/links/bookmarks.ts
+++ b/src/scripts/features/links/bookmarks.ts
@@ -14,7 +14,7 @@ import { storage } from '../../storage.ts'
 import type { Link, LinkElem } from '../../../types/shared.ts'
 import type { Sync } from '../../../types/sync.ts'
 
-type Treenode = browser.bookmarks.BookmarkTreeNode
+export type Treenode = browser.bookmarks.BookmarkTreeNode
 
 type BookmarksFolder = {
     title: string

--- a/tests/bookmarks.test.ts
+++ b/tests/bookmarks.test.ts
@@ -1,0 +1,84 @@
+import './init.test.ts'
+
+import { assertEquals } from '@std/assert'
+
+document.body.innerHTML = `
+    <main id="interface"></main>
+    <dialog id="contextmenu"></dialog>
+    <div id="linkblocks"></div>
+`
+
+const { SYNC_DEFAULT } = await import('../src/scripts/defaults.ts')
+const { initBookmarkSync, syncBookmarks } = await import('../src/scripts/features/links/bookmarks.ts')
+
+const toolbarTitle = 'Bookmarks Toolbar'
+
+type Bookmark = browser.bookmarks.BookmarkTreeNode
+type SyncedLinks = ReturnType<typeof syncBookmarks>
+
+function setBookmarks(bookmarks: Bookmark[]): void {
+    globalThis.startupBookmarks = [
+        {
+            id: 'root',
+            title: '',
+            children: [
+                {
+                    id: 'toolbar',
+                    title: toolbarTitle,
+                    children: bookmarks,
+                },
+            ],
+        },
+    ]
+    globalThis.startupTopsites = []
+}
+
+async function syncToolbar(bookmarks: Bookmark[]): Promise<SyncedLinks> {
+    setBookmarks(bookmarks)
+    await initBookmarkSync(structuredClone(SYNC_DEFAULT))
+
+    return syncBookmarks(toolbarTitle)
+}
+
+function linkUrls(links: SyncedLinks): string[] {
+    return links.flatMap((link) => link.folder ? [] : [link.url])
+}
+
+function linkTitles(links: SyncedLinks): string[] {
+    return links.flatMap((link) => link.folder ? [] : [link.title])
+}
+
+Deno.test({
+    name: 'Bookmark sync ignores Firefox separators',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+        const links = await syncToolbar([
+            { id: 'separator-normalized', title: '', url: 'https://data/' },
+            { id: 'separator-data-url', title: '', url: 'data:text/plain;charset=utf-8,' },
+            { id: 'deno', title: 'Deno', url: 'https://deno.com/' },
+            { id: 'untitled', title: '', url: 'https://example.com/' },
+            { id: 'hostless', title: '', url: 'about:blank' },
+        ])
+
+        assertEquals(linkUrls(links), ['https://deno.com/', 'https://example.com/', '#about:blank'])
+        assertEquals(linkTitles(links), ['Deno', '', ''])
+    },
+})
+
+Deno.test({
+    name: 'Bookmark sync keeps separators out after resync',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+        const bookmarks = [
+            { id: 'separator-normalized', title: '', url: 'https://data/' },
+            { id: 'example', title: 'Example', url: 'https://example.com/' },
+        ]
+
+        await syncToolbar(bookmarks)
+        const links = await syncToolbar(bookmarks)
+
+        assertEquals(linkUrls(links), ['https://example.com/'])
+    },
+})

--- a/tests/bookmarks.test.ts
+++ b/tests/bookmarks.test.ts
@@ -1,52 +1,17 @@
 import './init.test.ts'
 
+import { initBookmarkSync, syncBookmarks } from '../src/scripts/features/links/bookmarks.ts'
+import { SYNC_DEFAULT } from '../src/scripts/defaults.ts'
 import { assertEquals } from '@std/assert'
+import type { Treenode } from '../src/scripts/features/links/bookmarks.ts'
+
+type SyncedLinks = ReturnType<typeof syncBookmarks>
 
 document.body.innerHTML = `
     <main id="interface"></main>
     <dialog id="contextmenu"></dialog>
     <div id="linkblocks"></div>
 `
-
-const { SYNC_DEFAULT } = await import('../src/scripts/defaults.ts')
-const { initBookmarkSync, syncBookmarks } = await import('../src/scripts/features/links/bookmarks.ts')
-
-const toolbarTitle = 'Bookmarks Toolbar'
-
-type Bookmark = browser.bookmarks.BookmarkTreeNode
-type SyncedLinks = ReturnType<typeof syncBookmarks>
-
-function setBookmarks(bookmarks: Bookmark[]): void {
-    globalThis.startupBookmarks = [
-        {
-            id: 'root',
-            title: '',
-            children: [
-                {
-                    id: 'toolbar',
-                    title: toolbarTitle,
-                    children: bookmarks,
-                },
-            ],
-        },
-    ]
-    globalThis.startupTopsites = []
-}
-
-async function syncToolbar(bookmarks: Bookmark[]): Promise<SyncedLinks> {
-    setBookmarks(bookmarks)
-    await initBookmarkSync(structuredClone(SYNC_DEFAULT))
-
-    return syncBookmarks(toolbarTitle)
-}
-
-function linkUrls(links: SyncedLinks): string[] {
-    return links.flatMap((link) => link.folder ? [] : [link.url])
-}
-
-function linkTitles(links: SyncedLinks): string[] {
-    return links.flatMap((link) => link.folder ? [] : [link.title])
-}
 
 Deno.test({
     name: 'Bookmark sync ignores Firefox separators',
@@ -82,3 +47,34 @@ Deno.test({
         assertEquals(linkUrls(links), ['https://example.com/'])
     },
 })
+
+/*
+ * Functions
+ */
+
+function setBookmarks(bookmarks: Treenode[]): void {
+    globalThis.startupBookmarks = [{
+        id: 'root',
+        title: '',
+        children: [{
+            id: 'toolbar',
+            title: 'Bookmarks Toolbar',
+            children: bookmarks,
+        }],
+    }]
+    globalThis.startupTopsites = []
+}
+
+async function syncToolbar(bookmarks: Treenode[]): Promise<SyncedLinks> {
+    setBookmarks(bookmarks)
+    await initBookmarkSync(structuredClone(SYNC_DEFAULT))
+    return syncBookmarks('Bookmarks Toolbar')
+}
+
+function linkUrls(links: SyncedLinks): string[] {
+    return links.flatMap((link) => link.folder ? [] : [link.url])
+}
+
+function linkTitles(links: SyncedLinks): string[] {
+    return links.flatMap((link) => link.folder ? [] : [link.title])
+}

--- a/tests/features/bookmarks.test.ts
+++ b/tests/features/bookmarks.test.ts
@@ -1,9 +1,9 @@
-import './init.test.ts'
-
-import { initBookmarkSync, syncBookmarks } from '../src/scripts/features/links/bookmarks.ts'
-import { SYNC_DEFAULT } from '../src/scripts/defaults.ts'
+import '../init.test.ts'
 import { assertEquals } from '@std/assert'
-import type { Treenode } from '../src/scripts/features/links/bookmarks.ts'
+
+import { initBookmarkSync, syncBookmarks } from '../../src/scripts/features/links/bookmarks.ts'
+import { SYNC_DEFAULT } from '../../src/scripts/defaults.ts'
+import type { Treenode } from '../../src/scripts/features/links/bookmarks.ts'
 
 type SyncedLinks = ReturnType<typeof syncBookmarks>
 


### PR DESCRIPTION
## Summary

Firefox represents a Bookmarks Toolbar separator as a bookmark with an empty title and a `data:` URL that the browser normalizes to `https://data/`. When such a folder was synced to Quick links, the separator turned into a broken `?` icon link in the grid. This change skips those separator entries during sync so only real bookmarks become Quick links.

## Why this matters

Reported in #753: adding a separator to the Firefox Bookmarks Toolbar and syncing it produced a spurious "data" link. The fix is applied in `bookmarkTreeToFolderList()`, the single point both initial sync and re-sync flow through, so the separator never reaches `validateLink()`.

## How separators are detected

A bookmark is treated as a separator only when its title is empty AND its URL is the Firefox placeholder: a `data:` scheme URL, or a URL whose host is exactly `data` (the normalized `https://data/` form). Titleless bookmarks with a real host (for example `https://example.com/` or `about:blank`) are kept, so valid untitled bookmarks are not dropped.

## Testing

- `deno test --allow-read --allow-env tests/bookmarks.test.ts` (new tests, run repeatedly: no flakes)
- `deno test --allow-read --allow-env --reporter=dot` (full suite: 8 passed, 20 steps)
- `deno check` on the changed files
- `deno fmt` on the changed files

New tests in `tests/bookmarks.test.ts` cover: `https://data/` and `data:` separators are dropped, normal bookmarks sync, a titleless `https://example.com/` and `about:blank` bookmark are preserved, and re-syncing stays idempotent.

Fixes #753

AI was used for assistance.
