### PR TITLE
Disablable alt mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 22.2.2
+## 22.3.0
 
+- Added advanced settings toggleable directly from JSON:
+    - `altMode` to disable the Alt Mode
+    - `escKey` to disable the escape key toggling settings
 - Fixed broken settings and context menu for RTL (right to left) languages
 - Fixed pomodoro widget not alignable using layout toolbox's text alignment
 - Fixed some quick links styling issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added advanced settings toggleable directly from JSON:
     - `altMode` to disable the Alt Mode
     - `escKey` to disable the escape key toggling settings
+- Apply settings management's JSON with `cmd/ctrl + enter` keybind
 - Fixed broken settings and context menu for RTL (right to left) languages
 - Fixed pomodoro widget not alignable using layout toolbox's text alignment
 - Fixed some quick links styling issues

--- a/src/manifests/chrome.json
+++ b/src/manifests/chrome.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "__MSG_extensionName__",
     "short_name": "Bonjourr",
-    "version": "22.2.2",
+    "version": "22.3.0",
     "description": "__MSG_extensionDesc__",
     "author": "Victor Azevedo and Tahoe Beetschen",
     "default_locale": "en",

--- a/src/manifests/edge.json
+++ b/src/manifests/edge.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "__MSG_extensionName__",
     "short_name": "Bonjourr",
-    "version": "22.2.2",
+    "version": "22.3.0",
     "description": "__MSG_extensionDesc__",
     "author": "Victor Azevedo and Tahoe Beetschen",
     "default_locale": "en",

--- a/src/manifests/firefox.json
+++ b/src/manifests/firefox.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "__MSG_extensionName__",
     "short_name": "Bonjourr",
-    "version": "22.2.2",
+    "version": "22.3.0",
     "description": "__MSG_extensionDesc__",
     "author": "Victor Azevedo and Tahoe Beetschen",
     "homepage_url": "https://bonjourr.fr",

--- a/src/scripts/compatibility/filters.ts
+++ b/src/scripts/compatibility/filters.ts
@@ -11,6 +11,16 @@ import type { Sync } from '../../types/sync.ts'
 
 type Import = Partial<Sync>
 
+export function addAdvancedOptions(data: Import): Import {
+    if (!data.advanced) {
+        data.advanced = SYNC_DEFAULT.advanced
+    }
+
+    data.advanced = data.advanced ?? SYNC_DEFAULT.advanced
+
+    return data
+}
+
 export function addShowUnitToWeather(data: Import): Import {
     if (!data.weather) {
         data.weather = SYNC_DEFAULT.weather

--- a/src/scripts/compatibility/versions.ts
+++ b/src/scripts/compatibility/versions.ts
@@ -16,6 +16,10 @@ export function filterByVersion(data: Partial<Sync>, version: SemVer): Partial<S
             data = filter.addColorToFont(data)
             data = filter.addShowUnitToWeather(data)
         }
+
+        if (minor < 3) {
+            data = filter.addAdvancedOptions(data)
+        }
     }
 
     if (major <= 21) {

--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -8,7 +8,7 @@ const navigator = globalThis.navigator as Navigator
 const iosUA = 'iPad Simulator|iPhone Simulator|iPod Simulator|iPad|iPhone|iPod'.split('|')
 const mobileUA = 'Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini'.split('|')
 
-export const CURRENT_VERSION = '22.2.2'
+export const CURRENT_VERSION = '22.3.0'
 
 export const API_DOMAIN = 'https://services.bonjourr.fr'
 

--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -97,7 +97,7 @@ export const SYNC_DEFAULT: Sync = {
     },
     advanced: {
         altMode: true,
-        escKey: true
+        escKey: true,
     },
     showall: false,
     lang: DEFAULT_LANG,

--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -95,6 +95,9 @@ export const SYNC_DEFAULT: Sync = {
         browser: PLATFORM,
         version: CURRENT_VERSION,
     },
+    advanced: {
+        altMode: true,
+    },
     showall: false,
     lang: DEFAULT_LANG,
     dark: 'system',

--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -97,6 +97,7 @@ export const SYNC_DEFAULT: Sync = {
     },
     advanced: {
         altMode: true,
+        escKey: true
     },
     showall: false,
     lang: DEFAULT_LANG,

--- a/src/scripts/events.ts
+++ b/src/scripts/events.ts
@@ -1,19 +1,27 @@
+import type { Advanced } from '../types/sync.ts'
+
 import { isTypingTarget } from './features/links/helpers.ts'
 
 let isMousingDownOnInput = false
 
-export function userActions(): void {
+export function userActions(advanced: Advanced): void {
     document.body.addEventListener('mousedown', detectTargetAsInputs)
     document.getElementById('b_editmove')?.addEventListener('click', closeSettingsOnMoveOpen)
 
     document.addEventListener('click', clickUserActions)
-    document.addEventListener('keydown', keyboardUserActions)
-    document.addEventListener('keyup', keyboardUserActions)
+
+    document.addEventListener('keydown', (event) => {
+        keyboardUserActions(advanced, event)
+    })
+
+    document.addEventListener('keyup', (event) => {
+        keyboardUserActions(advanced, event)
+    })
 }
 
 // Main functions
 
-function keyboardUserActions(event: KeyboardEvent): void {
+function keyboardUserActions(advanced: Advanced, event: KeyboardEvent): void {
     const { altKey, ctrlKey, metaKey, code, type } = event
 
     const domsuggestions = document.getElementById('sb-suggestions')
@@ -30,7 +38,7 @@ function keyboardUserActions(event: KeyboardEvent): void {
         if (open.contextmenu) {
             document.dispatchEvent(new Event('close-edit'))
         } //
-        else if (open.settings && keyup) {
+        else if (advanced.escKey && open.settings && keyup) {
             document.dispatchEvent(new CustomEvent('toggle-settings'))
         } //
         else if (open.selectall) {
@@ -39,7 +47,7 @@ function keyboardUserActions(event: KeyboardEvent): void {
         else if (open.folder) {
             document.dispatchEvent(new Event('close-folder'))
         } //
-        else if (keyup) {
+        else if (advanced.escKey && keyup) {
             // condition to avoid conflicts with esc key on supporters modal
             // likely to be improved
             if (document.documentElement.dataset.supportersModal === undefined) {

--- a/src/scripts/features/links/helpers.ts
+++ b/src/scripts/features/links/helpers.ts
@@ -126,9 +126,3 @@ export function isTypingTarget(target: EventTarget | null): boolean {
         )
     )
 }
-
-// disabling alt mode through the console with:
-// localStorage.setItem('disableAltMode', true)
-export function altModeIsDisabled(): boolean {
-    return localStorage.getItem('disableAltMode') === 'true'
-}

--- a/src/scripts/features/links/helpers.ts
+++ b/src/scripts/features/links/helpers.ts
@@ -126,3 +126,9 @@ export function isTypingTarget(target: EventTarget | null): boolean {
         )
     )
 }
+
+// disabling alt mode through the console with:
+// localStorage.setItem('disableAltMode', true)
+export function altModeIsDisabled(): boolean {
+    return localStorage.getItem('disableAltMode') === 'true'
+}

--- a/src/scripts/features/links/index.ts
+++ b/src/scripts/features/links/index.ts
@@ -127,7 +127,7 @@ export async function quickLinks(init?: LinksInit, event?: LinksUpdate): Promise
     domlinkblocks.classList.toggle('hidden', !sync.quicklinks)
 
     document.addEventListener('keydown', (event) => {
-        openLinksWithKeyboard(init.sync, event)
+        openLinksWithKeyboard(init.sync.advanced, event)
     })
 
     if (sync.linkgroups.synced.length > 0) {

--- a/src/scripts/features/links/index.ts
+++ b/src/scripts/features/links/index.ts
@@ -13,6 +13,7 @@ import {
     isElem,
     isLink,
     isTypingTarget,
+    altModeIsDisabled
 } from './helpers.ts'
 
 import { randomString, stringMaxSize } from '../../shared/generic.ts'
@@ -921,7 +922,7 @@ function isLinkStyle(s: string): s is Sync['linkstyle'] {
 }
 
 function openLinksWithKeyboard(event: KeyboardEvent): void {
-    if (isTypingTarget(event.target)) return
+    if (isTypingTarget(event.target) || altModeIsDisabled()) return
 
     const { altKey, ctrlKey, metaKey, code } = event
     const isNotAltComboKey = !altKey || ctrlKey || metaKey

--- a/src/scripts/features/links/index.ts
+++ b/src/scripts/features/links/index.ts
@@ -24,7 +24,7 @@ import { storage } from '../../storage.ts'
 
 import type { Link, LinkElem, LinkFolder, LinkIcon } from '../../../types/shared.ts'
 import type { Local } from '../../../types/local.ts'
-import type { Sync } from '../../../types/sync.ts'
+import type { Advanced, Sync } from '../../../types/sync.ts'
 
 type AddLinks = {
     title: string
@@ -922,8 +922,8 @@ function isLinkStyle(s: string): s is Sync['linkstyle'] {
     return ['large', 'medium', 'small', 'inline', 'text'].includes(s)
 }
 
-function openLinksWithKeyboard(data: Sync, event: KeyboardEvent): void {
-    if (isTypingTarget(event.target) || !data.advanced.altMode) return
+function openLinksWithKeyboard(advanced: Advanced, event: KeyboardEvent): void {
+    if (isTypingTarget(event.target) || !advanced.altMode) return
 
     const { altKey, ctrlKey, metaKey, code } = event
     const isNotAltComboKey = !altKey || ctrlKey || metaKey

--- a/src/scripts/features/links/index.ts
+++ b/src/scripts/features/links/index.ts
@@ -13,7 +13,6 @@ import {
     isElem,
     isLink,
     isTypingTarget,
-    altModeIsDisabled
 } from './helpers.ts'
 
 import { randomString, stringMaxSize } from '../../shared/generic.ts'
@@ -127,7 +126,9 @@ export async function quickLinks(init?: LinksInit, event?: LinksUpdate): Promise
     domlinkblocks.classList.toggle('backgrounds', sync.linkbackgrounds)
     domlinkblocks.classList.toggle('hidden', !sync.quicklinks)
 
-    document.addEventListener('keydown', openLinksWithKeyboard)
+    document.addEventListener('keydown', (event) => {
+        openLinksWithKeyboard(init.sync, event)
+    })
 
     if (sync.linkgroups.synced.length > 0) {
         await initBookmarkSync(sync)
@@ -921,8 +922,8 @@ function isLinkStyle(s: string): s is Sync['linkstyle'] {
     return ['large', 'medium', 'small', 'inline', 'text'].includes(s)
 }
 
-function openLinksWithKeyboard(event: KeyboardEvent): void {
-    if (isTypingTarget(event.target) || altModeIsDisabled()) return
+function openLinksWithKeyboard(data: Sync, event: KeyboardEvent): void {
+    if (isTypingTarget(event.target) || !data.advanced.altMode) return
 
     const { altKey, ctrlKey, metaKey, code } = event
     const isNotAltComboKey = !altKey || ctrlKey || metaKey

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -110,7 +110,7 @@ async function startup(): Promise<void> {
 
         supportersNotifications(sync)
         setPotatoComputerMode()
-        userActions()
+        userActions(sync.advanced)
 
         interfacePopup({
             announce: sync.announcements,

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -16,7 +16,6 @@ import { notes } from './features/notes.ts'
 import { clock } from './features/clock/index.ts'
 import './features/contextmenu.ts'
 
-import { altModeIsDisabled } from './features/links/helpers.ts'
 import { displayInterface, onInterfaceDisplay } from './shared/display.ts'
 import { setTranslationCache, traduction } from './utils/translations.ts'
 import { operaExtensionExplainer } from './startup/opera.ts'
@@ -95,7 +94,7 @@ async function startup(): Promise<void> {
     operaExtensionExplainer(local.operaExplained)
     tabsTracking()
 
-    if (!altModeIsDisabled()) {
+    if (sync.advanced.altMode) {
         altMode()
     }
 

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -16,6 +16,7 @@ import { notes } from './features/notes.ts'
 import { clock } from './features/clock/index.ts'
 import './features/contextmenu.ts'
 
+import { altModeIsDisabled } from './features/links/helpers.ts'
 import { displayInterface, onInterfaceDisplay } from './shared/display.ts'
 import { setTranslationCache, traduction } from './utils/translations.ts'
 import { operaExtensionExplainer } from './startup/opera.ts'
@@ -93,7 +94,10 @@ async function startup(): Promise<void> {
     pageControl({ width: sync.pagewidth, gap: sync.pagegap })
     operaExtensionExplainer(local.operaExplained)
     tabsTracking()
-    altMode()
+
+    if (!altModeIsDisabled()) {
+        altMode()
+    }
 
     document.documentElement.dataset.system = SYSTEM_OS as string
     document.documentElement.dataset.browser = BROWSER as string

--- a/src/scripts/services/service-worker.js
+++ b/src/scripts/services/service-worker.js
@@ -9,7 +9,7 @@ if (globalThis.chrome) {
     self.addEventListener('fetch', retrieveCache)
 }
 
-const CACHE_KEY = '22.2.2'
+const CACHE_KEY = '22.3.0'
 const API_URLS = ['unsplash.com', 'jsdelivr.net', 'api.bonjourr']
 
 // Web Extension

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -1076,6 +1076,14 @@ function initOptionsEvents(): void {
         importSettings(parse<Partial<Sync>>(val) ?? {})
     })
 
+    // applies settings-data when cmd/ctrl + enter
+    paramId('settings-data').addEventListener('keydown', (event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+            event.preventDefault()
+            paramId('b_settings-apply').click()
+        }
+    })
+
     onclickdown(paramId('b_reset-first'), () => {
         resetSettings('first')
     })

--- a/src/styles/features/links.css
+++ b/src/styles/features/links.css
@@ -636,7 +636,6 @@
     border-radius: 8px;
 }
 
-
 /* Folder styles for medium and small */
 
 .medium .link-folder .link-icon,
@@ -807,7 +806,7 @@
 
 #link-mini button:not(.selected-group) {
     text-shadow: var(--text-shadow-interface);
-    overflow: visible; /* otherwise shadow has borders */ 
+    overflow: visible; /* otherwise shadow has borders */
 }
 
 .link-group.in-folder + #link-mini {

--- a/src/styles/settings/inputs.css
+++ b/src/styles/settings/inputs.css
@@ -234,8 +234,7 @@ aside input[type='range']::-webkit-slider-runnable-track {
 
 html:dir(rtl) aside input[type='range']::-webkit-slider-runnable-track {
     background:
-        linear-gradient(rgb(var(--accent-color)), rgb(var(--accent-color)))
-        right / var(--sx) 100% no-repeat,
+        linear-gradient(rgb(var(--accent-color)), rgb(var(--accent-color))) right / var(--sx) 100% no-repeat,
         #efefef;
 }
 
@@ -268,8 +267,7 @@ aside input[type='range']::-moz-range-track {
 
 html:dir(rtl) aside input[type='range']::-moz-range-track {
     background:
-        linear-gradient(rgb(var(--accent-color)), rgb(var(--accent-color)))
-        right / var(--sx) 100% no-repeat,
+        linear-gradient(rgb(var(--accent-color)), rgb(var(--accent-color))) right / var(--sx) 100% no-repeat,
         #efefef;
 }
 

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -1,6 +1,7 @@
 import type { BackgroundImage, BackgroundVideo, Frequency, Link, PomodoroMode, Widgets } from './shared.ts'
 
 export interface Sync {
+    advanced: Advanced
     showall: boolean
     quicklinks: boolean
     time: boolean
@@ -233,4 +234,8 @@ export interface Pomodoro {
         endedAt: string
         duration: number
     }[]
+}
+
+export interface Advanced {
+    altMode: boolean
 }

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -238,4 +238,6 @@ export interface Pomodoro {
 
 export interface Advanced {
     altMode: boolean
+    // disables escape key to toggle settings
+    escKey: boolean
 }

--- a/tasks/archive.ts
+++ b/tasks/archive.ts
@@ -1,4 +1,4 @@
-const VERSION = '22.2.2'
+const VERSION = '22.3.0'
 
 buildPlatforms()
 archiveSource()


### PR DESCRIPTION
What do we think of this, @victrme? Instead of having a full on toggle in the settings for such a tiny nerdy thing, have it be toggleable via the console instead. Could be a solution for disabling both the alt mode and the esc key (#316)