### PR TITLE
fix: open search results in new tab with noopener to avoid opener flash

### DIFF
--- a/src/scripts/features/searchbar.ts
+++ b/src/scripts/features/searchbar.ts
@@ -242,9 +242,12 @@ function submitSearch(e: Event): void {
     const domainUrl = hasProtocol ? val : `https://${val}`
     const searchUrl = createSearchUrl(val, engine)
     const url = isValidUrl(domainUrl) ? domainUrl : searchUrl
-    const target = newtab ? '_blank' : '_self'
+    if (newtab) {
+        globalThis.open(url, '_blank', 'noopener')
+        return
+    }
 
-    globalThis.open(url, target)
+    globalThis.open(url, '_self')
     return
 }
 

--- a/tests/features/searchbar.test.ts
+++ b/tests/features/searchbar.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from '@std/assert'
+import '../init.ts'
+
+document.body.innerHTML = `
+    <main id="interface"></main>
+    <dialog id="contextmenu"></dialog>
+    <button id="b_interface-quotes-refresh"></button>
+    <form id="sb_container">
+        <input id="searchbar" />
+    </form>
+`
+
+const { searchbar } = await import('../../src/scripts/features/searchbar.ts')
+
+searchbar()
+
+Deno.test({
+    name: 'Search opens results in a new tab without an opener',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: () => {
+        assertEquals(submitSearch('bonjourr', true), [
+            ['https://duckduckgo.com/?q=bonjourr', '_blank', 'noopener'],
+        ])
+    },
+})
+
+Deno.test({
+    name: 'Search opens results in the current tab without new-tab features',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: () => {
+        assertEquals(submitSearch('bonjourr', false), [
+            ['https://duckduckgo.com/?q=bonjourr', '_self'],
+        ])
+    },
+})
+
+Deno.test({
+    name: 'Search opens bare domains in a new tab without an opener',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: () => {
+        assertEquals(submitSearch('example.com', true), [
+            ['https://example.com', '_blank', 'noopener'],
+        ])
+    },
+})
+
+Deno.test({
+    name: 'Search does not open a page for empty input',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: () => {
+        assertEquals(submitSearch('', true), [])
+    },
+})
+
+/*
+ * Functions
+ */
+
+function submitSearch(value: string, newtab: boolean): unknown[][] {
+    const container = document.getElementById('sb_container') as HTMLFormElement
+    const input = document.getElementById('searchbar') as HTMLInputElement
+    const calls: unknown[][] = []
+    const originalOpen = globalThis.open
+
+    container.dataset.engine = 'ddg'
+    container.dataset.newtab = newtab.toString()
+    input.value = value
+    globalThis.open = ((...args: unknown[]) => {
+        calls.push(args)
+        return null
+    }) as typeof globalThis.open
+
+    try {
+        container.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    } finally {
+        globalThis.open = originalOpen
+    }
+
+    return calls
+}


### PR DESCRIPTION
## Summary
Search results opened with "Open in new tab" no longer flash the wallpaper color before the destination loads. The search bar now opens new tabs with `noopener`, matching how quick links already behave.

## Why this matters
The reporter in #734 narrowed the flash down to the configured Bonjourr background and noted quick links do not flash. The cause is in `submitSearch()` (src/scripts/features/searchbar.ts): `globalThis.open(url, '_blank')` keeps the opener relationship, so the new tab starts in the same browsing-context group and paints with Bonjourr's rendered background until the search page's first paint. Quick links open through an anchor with `target="_blank"`, which gets an implicit `rel=noopener` and a fresh context group, which is why they never flashed.

## Changes
- The `newtab` branch of `submitSearch()` passes the `noopener` window feature, so the new tab gets its own browsing-context group. The `_self` path is untouched, and the unused return value of `open()` means there is no behavior change beyond the paint.

## Testing
Added `tests/features/searchbar.test.ts` (same style as `tests/features/bookmarks.test.ts`): stubs `globalThis.open`, submits the searchbar form with the new-tab option enabled, and asserts the call includes `noopener`; also asserts the current-tab path still targets `_self` without it.

Fixes #734
