### PR TITLE
fix: harden wallpaper upload pipeline + background rendering (bugs, potato mode, leaks, and a buncha other stuff)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -37,6 +37,7 @@
             "tests",
             "_locales"
         ],
+        "exclude": ["src/assets/effects"],
         "rules": {
             "tags": [
                 "recommended"
@@ -67,7 +68,7 @@
             "tests",
             "_locales"
         ],
-        "exclude": ["**/overview.md"]
+        "exclude": ["**/overview.md", "src/assets/effects"]
     },
     "compilerOptions": {
         "strict": true,

--- a/src/assets/effects/firefly.html
+++ b/src/assets/effects/firefly.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Firefly</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      width: 100%; height: 100%;
+      /* Transparent -- this iframe is an overlay layered on top of
+         Bonjourr's actual background (photo/video/color), not a
+         standalone scene, so the real background shows through. */
+      background: transparent;
+      overflow: hidden;
+    }
+
+    #firefly-canvas {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="firefly-canvas"></canvas>
+
+  <!-- <!> Loaded as an external file, not inline, because Manifest V3's
+       extension-page CSP (script-src 'self') blocks inline <script> tags
+       even for a page the extension ships itself. -->
+  <script src="firefly.js"></script>
+</body>
+</html>

--- a/src/assets/effects/firefly.js
+++ b/src/assets/effects/firefly.js
@@ -1,0 +1,233 @@
+(function () {
+  var canvas = document.getElementById('firefly-canvas');
+  var ctx    = canvas.getContext('2d');
+  var dpr    = Math.min(window.devicePixelRatio || 1, 2);
+  var W = 0, H = 0;
+  var flies  = [];
+  var pointer = { x: 0, y: 0, active: false };
+  var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Warm-white & soft-pastel palette (warm dominant)
+  var PALETTE = [
+    [255, 236, 188], [255, 226, 160], [255, 244, 214],   // warm whites / amber
+    [255, 236, 188], [255, 226, 160],                     // (weighted heavier)
+    [196, 169, 228],                                      // lilac
+    [156, 196, 232],                                      // blue
+    [168, 216, 188],                                      // sage
+    [230, 169, 204]                                       // pink
+  ];
+
+  function count() {
+    if (window.innerWidth < 480) return 22;
+    if (window.innerWidth < 768) return 34;
+    return 52;
+  }
+
+  // ---- Fly --------------------------------------------------------
+
+  function Fly(init) { this.reset(init); }
+
+  Fly.prototype.reset = function (init) {
+    this.x = Math.random() * W;
+    // bias spawn toward lower half so density thins as they rise
+    this.y = init
+      ? H * (1 - Math.pow(Math.random(), 1.7))
+      : H + 20 + Math.random() * 40;
+    this.vy     = -(0.20 + Math.random() * 0.5);   // gentle upward drift
+    this.vx     = (Math.random() - 0.5) * 0.16;
+    this.phase  = Math.random() * Math.PI * 2;
+    this.driftF = 0.008 + Math.random() * 0.018;   // sway frequency
+    this.driftA = 0.5   + Math.random() * 1.4;     // sway amplitude
+    this.size   = 1.1   + Math.random() * 2.2;
+    this.glow   = this.size * (7 + Math.random() * 9);
+    this.baseOp = 0.4   + Math.random() * 0.55;
+    this.opacity = 0;
+    this.blinkP = Math.random() * Math.PI * 2;
+    this.blinkS = 0.02  + Math.random() * 0.05;    // blink speed
+    this.life   = 0;
+    this.curious = 0;
+    this.flash  = 0;
+    var c = PALETTE[(Math.random() * PALETTE.length) | 0];
+    this.r = c[0]; this.g = c[1]; this.b = c[2];
+  };
+
+  Fly.prototype.update = function () {
+    this.life++;
+    var fadeIn     = Math.min(1, this.life / 55);
+    // dim as they climb (ethereal thinning)
+    var yr         = this.y / H;
+    var heightFade = Math.pow(Math.max(0, Math.min(1, yr * 1.12)), 0.9);
+    var blink      = 0.6 + 0.4 * Math.sin(this.blinkP + this.life * this.blinkS);
+    this.opacity   = this.baseOp * fadeIn * heightFade * blink;
+
+    // curious: drift toward pointer, brighten when close
+    if (pointer.active) {
+      var pdx = pointer.x - this.x, pdy = pointer.y - this.y;
+      var pd  = Math.sqrt(pdx * pdx + pdy * pdy);
+      var R   = 150;
+      if (pd < R) {
+        var k = 1 - pd / R;
+        this.x += (pdx / (pd || 1)) * k * 0.55;
+        this.y += (pdy / (pd || 1)) * k * 0.55;
+        if (k > this.curious) this.curious = k;
+      }
+    }
+    if (this.curious > 0.001) {
+      this.opacity  = Math.min(1, this.opacity * (1 + this.curious * 1.1));
+      this.curious *= 0.93;
+    }
+
+    // flash (from clicks)
+    if (this.flash > 0.001) {
+      this.opacity  = Math.min(1, this.opacity + this.flash * 0.7);
+      this.flash   *= 0.95;
+    }
+
+    this.x += this.vx + Math.sin(this.phase + this.life * this.driftF) * this.driftA * 0.1;
+    this.y += this.vy;
+    if (this.y < -30) this.reset(false);  // recycle off the top
+  };
+
+  Fly.prototype.draw = function () {
+    if (this.opacity < 0.01) return;
+    var x = this.x, y = this.y, r = this.r, g = this.g, b = this.b, op = this.opacity;
+
+    // outer glow
+    var og = ctx.createRadialGradient(x, y, 0, x, y, this.glow);
+    og.addColorStop(0,    'rgba(' + r + ',' + g + ',' + b + ',' + (op * 0.6)  + ')');
+    og.addColorStop(0.45, 'rgba(' + r + ',' + g + ',' + b + ',' + (op * 0.16) + ')');
+    og.addColorStop(1,    'rgba(' + r + ',' + g + ',' + b + ',0)');
+    ctx.beginPath();
+    ctx.arc(x, y, this.glow, 0, Math.PI * 2);
+    ctx.fillStyle = og;
+    ctx.fill();
+
+    // warm-white core
+    var cg = ctx.createRadialGradient(x, y, 0, x, y, this.size * 2);
+    cg.addColorStop(0,   'rgba(255,250,240,' + Math.min(1, op * 1.5) + ')');
+    cg.addColorStop(0.5, 'rgba(' + r + ',' + g + ',' + b + ',' + op + ')');
+    cg.addColorStop(1,   'rgba(' + r + ',' + g + ',' + b + ',0)');
+    ctx.beginPath();
+    ctx.arc(x, y, this.size * 2, 0, Math.PI * 2);
+    ctx.fillStyle = cg;
+    ctx.fill();
+  };
+
+  // ---- resize / loop ----------------------------------------------
+
+  function resize() {
+    W = window.innerWidth;
+    H = window.innerHeight;
+    canvas.width  = W * dpr;
+    canvas.height = H * dpr;
+    canvas.style.width  = W + 'px';
+    canvas.style.height = H + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    flies = [];
+    var n = count();
+    for (var i = 0; i < n; i++) flies.push(new Fly(true));
+  }
+
+  var raf = null;
+
+  function loop() {
+    ctx.clearRect(0, 0, W, H);
+    ctx.globalCompositeOperation = 'lighter';
+    for (var i = 0; i < flies.length; i++) { flies[i].update(); flies[i].draw(); }
+    ctx.globalCompositeOperation = 'source-over';
+    raf = window.requestAnimationFrame(loop);
+  }
+
+  function drawStatic() {
+    ctx.clearRect(0, 0, W, H);
+    ctx.globalCompositeOperation = 'lighter';
+    for (var i = 0; i < flies.length; i++) {
+      flies[i].opacity = flies[i].baseOp * 0.85;
+      flies[i].draw();
+    }
+    ctx.globalCompositeOperation = 'source-over';
+  }
+
+  // ---- pointer ----------------------------------------------------
+  // <!> Bonjourr mounts this inside a `pointer-events: none` iframe (a
+  // <!> background layer must never intercept clicks meant for the
+  // <!> interface above it), so these pointer/click/keydown listeners are
+  // <!> effectively inert there -- kept as-is anyway so the file still
+  // <!> behaves identically if ever opened standalone.
+
+  window.addEventListener('pointermove', function (e) {
+    pointer.x = e.clientX;
+    pointer.y = e.clientY;
+    pointer.active = true;
+  }, { passive: true });
+
+  window.addEventListener('pointerout', function (e) {
+    if (!e.relatedTarget) pointer.active = false;
+  });
+
+  window.addEventListener('blur', function () { pointer.active = false; });
+
+  // ---- release (click) --------------------------------------------
+
+  function pickDim(n) {
+    return flies
+      .slice()
+      .sort(function (a, b) { return a.opacity - b.opacity; })
+      .slice(0, n);
+  }
+
+  function release(opts) {
+    opts = opts || {};
+    var n = Math.min(opts.count || 6, flies.length);
+    pickDim(n).forEach(function (f) {
+      if (opts.x != null) {
+        f.x  = opts.x + (Math.random() - 0.5) * 26;
+        f.y  = opts.y + (Math.random() - 0.5) * 18;
+        f.vy = -(0.5  + Math.random() * 0.7);
+        f.vx = (Math.random() - 0.5) * 0.6;
+        f.size  = 1.5 + Math.random() * 1.6;
+        f.flash = 1.1;
+      } else {
+        f.x  = Math.random() * W;
+        f.y  = H * 0.62 + Math.random() * H * 0.38;
+        f.vy = -(0.4  + Math.random() * 0.7);
+        f.vx = (Math.random() - 0.5) * 0.5;
+        f.size  = 1.5 + Math.random() * 1.6;
+        f.flash = 1.1;
+      }
+      f.glow    = f.size * (9 + Math.random() * 8);
+      f.life    = 60;
+      f.baseOp  = 0.8 + Math.random() * 0.2;
+      f.curious = 0;
+    });
+    if (reduceMotion) drawStatic();
+  }
+
+  window.addEventListener('click', function (e) {
+    release({ x: e.clientX, y: e.clientY, count: 6 });
+  });
+
+  // keyboard easter egg: type "firefly" anywhere to burst
+  var seq = '';
+  window.addEventListener('keydown', function (e) {
+    seq = (seq + e.key).slice(-7);
+    if (/firefly$/.test(seq)) release({ count: 12 });
+  });
+
+  // ---- init -------------------------------------------------------
+
+  resize();
+
+  var rt = null;
+  window.addEventListener('resize', function () {
+    clearTimeout(rt);
+    rt = setTimeout(function () {
+      if (raf) window.cancelAnimationFrame(raf);
+      resize();
+      if (reduceMotion) drawStatic(); else loop();
+    }, 180);
+  }, { passive: true });
+
+  if (reduceMotion) drawStatic(); else loop();
+
+})();

--- a/src/assets/effects/rain.html
+++ b/src/assets/effects/rain.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Cozy Rain</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body {
+    width: 100%; height: 100%;
+    /* Transparent -- this iframe is an overlay layered on top of
+       Bonjourr's actual background (photo/video/color), not a standalone
+       night scene, so the real background shows through underneath the
+       rain streaks/ripples/vignette. (Used to be an opaque night-sky
+       gradient painted here; the rain layer's own vignette and ground
+       sheen still give it mood without needing that gradient.) */
+    background: transparent;
+    overflow: hidden;
+    font-family: system-ui, sans-serif;
+  }
+  #rain { display: block; width: 100vw; height: 100vh; }
+</style>
+</head>
+<body>
+<canvas id="rain"></canvas>
+
+<!-- <!> Loaded as an external file, not inline, because Manifest V3's
+     extension-page CSP (script-src 'self') blocks inline <script> tags
+     even for a page the extension ships itself. -->
+<script src="rain.js"></script>
+</body>
+</html>

--- a/src/assets/effects/rain.js
+++ b/src/assets/effects/rain.js
@@ -1,0 +1,633 @@
+'use strict';
+
+/*
+  COZY RAIN v2 — physics + a few real rendering-literature techniques
+  ─────────────────────────────────────────────────────────────────
+  Fall speed: blended Gunn & Kinzer (1949) / Atlas & Ulbrich (1977) empirical
+  curves (v = 3.778*D^0.67, D in mm), capped near the real ~9.5 m/s ceiling.
+  Drop sizes: Marshall–Palmer exponential sampling, N(D) = N0*exp(-lambda*D),
+  lambda tracking a slowly-drifting simulated rain rate.
+  Wind: an Ornstein–Uhlenbeck process (dV = theta*(mean-V)*dt + sigma*sqrt(dt)*Z),
+  the standard model for temporally-correlated, mean-reverting wind speed
+  (e.g. Obukhov et al. 2021) — gusts build and decay coherently instead of
+  wobbling frame to frame. The long-run mean itself drifts slowly and is
+  biased negative (upper-right -> lower-left) but can fully reverse.
+  Splashes: energy-scaled (0.5*m*v^2, m~D^3) with 5th-root Weber-like
+  compression, and — per oblique-impact splash research (crown/ligament
+  formation concentrates on the leeward side under wind-driven impact,
+  e.g. studies of drop impact in crosswind) — the ripple is offset and
+  stretched toward the direction of travel rather than a perfect circle,
+  with secondary droplets biased the same way.
+  Depth: far-layer rain is drawn to a half-resolution offscreen canvas and
+  composited with a single drawImage — the half-to-full upscale already
+  gives a free soft-focus look, and it's cheaper than an explicit blur
+  filter, which cost roughly half the frame rate for barely more softness
+  in testing; mid is crisp, near is boosted for foreground presence.
+  Static and slow-moving background layers (vignette, glass sheen, cloud
+  light) are pre-rendered to small offscreen canvases and blitted rather
+  than re-rasterizing full-canvas gradients every frame — that turned out
+  to matter more than the blur at large (ultrawide) canvas sizes.
+  No ctx.save()/restore() in any per-particle path — every fill/stroke
+  style carries its own alpha baked in, so there's no per-frame global
+  state to push or leak between draws.
+*/
+
+// ── Canvas & offscreen far-layer setup ──────────────────────────────────
+const canvas = document.getElementById('rain');
+const ctx = canvas.getContext('2d');
+let W = 0, H = 0;
+let farCanvas, farCtx;
+
+// ── Small math utilities ────────────────────────────────────────────────
+const rnd = (a, b) => a + Math.random() * (b - a);
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+const lerp = (a, b, t) => a + (b - a) * t;
+const smoothstep = t => { t = clamp(t, 0, 1); return t * t * (3 - 2 * t); };
+
+let _spareGaussian = null;
+function gaussianRandom() {
+  if (_spareGaussian !== null) { const v = _spareGaussian; _spareGaussian = null; return v; }
+  let u = 0, v = 0;
+  while (u === 0) u = Math.random();
+  while (v === 0) v = Math.random();
+  const mag = Math.sqrt(-2 * Math.log(u));
+  _spareGaussian = mag * Math.sin(2 * Math.PI * v);
+  return mag * Math.cos(2 * Math.PI * v);
+}
+
+// 1D value noise (smoothstep-interpolated) — used only for the slow rain
+// rate drift, which doesn't need OU's autocorrelation properties.
+const NOISE_SIZE = 256;
+const noiseTable = Array.from({ length: NOISE_SIZE }, () => Math.random() * 2 - 1);
+function noise1D(x) {
+  const xi = Math.floor(x);
+  const xf = x - xi;
+  const i0 = ((xi % NOISE_SIZE) + NOISE_SIZE) % NOISE_SIZE;
+  const i1 = (i0 + 1) % NOISE_SIZE;
+  const t = smoothstep(xf);
+  return noiseTable[i0] * (1 - t) + noiseTable[i1] * t;
+}
+
+// ── Lightweight event hooks (sound-ready, renderer stays unaware) ──────
+// A future audio layer can subscribe without this file ever importing or
+// knowing about it — 'splash' fires per impact, 'ambient' about once a
+// second with the current simulated rain rate / wind so a mixer could
+// crossfade loops by intensity.
+const RainEvents = (() => {
+  const listeners = {};
+  return {
+    on(name, fn) { (listeners[name] = listeners[name] || []).push(fn); },
+    emit(name, data) { (listeners[name] || []).forEach(fn => fn(data)); },
+  };
+})();
+window.RainEvents = RainEvents;
+
+// ── Scale & physical constants ──────────────────────────────────────────
+const PPM = 130;                    // pixels per simulated metre
+const GRAVITY_PX = 9.81 * PPM;      // px / s^2
+
+// ── Palette ──────────────────────────────────────────────────────────────
+const PALETTE = {
+  offwhite: { r: 238, g: 241, b: 246 },
+  light:    { r: 195, g: 203, b: 216 },
+  medium:   { r: 143, g: 153, b: 171 },
+  gray:     { r: 109, g: 119, b: 136 },
+};
+function jitterColor(base, amt) {
+  return {
+    r: clamp(base.r + amt * 255, 0, 255) | 0,
+    g: clamp(base.g + amt * 255, 0, 255) | 0,
+    b: clamp(base.b + amt * 255, 0, 255) | 0,
+  };
+}
+function rgba(c, a) { return `rgba(${c.r},${c.g},${c.b},${clamp(a, 0, 1).toFixed(3)})`; }
+function pickDropColorObj(z) {
+  const r = Math.random();
+  let base;
+  if (z > 0.72) base = r < 0.55 ? PALETTE.offwhite : PALETTE.light;
+  else if (z > 0.40) base = r < 0.50 ? PALETTE.light : PALETTE.medium;
+  else base = r < 0.60 ? PALETTE.medium : PALETTE.gray;
+  return jitterColor(base, (Math.random() - 0.5) * 0.07);
+}
+
+// ── Wind: Ornstein–Uhlenbeck process ────────────────────────────────────
+// Coherent gusts, not per-frame wobble: speed mean-reverts toward a slowly
+// wandering long-run mean, with genuinely correlated random fluctuation
+// (Gaussian, not uniform noise) — the standard SDE model for real wind-
+// speed autocorrelation. Biased negative on average (rain leaning from
+// upper-right to lower-left) but the mean is free to cross zero and fully
+// reverse over a minute or two.
+const Wind = {
+  speed: -1.0, mean: -1.0, prevMean: -1.0, meanTarget: -1.0,
+  meanTimer: 0, meanDuration: 60,
+  theta: 0.24,   // reversion rate, 1/s
+  sigma: 0.46,   // volatility, (m/s)/sqrt(s)
+  update(dt) {
+    this.meanTimer += dt;
+    if (this.meanTimer >= this.meanDuration) {
+      this.meanTimer = 0;
+      this.meanDuration = rnd(55, 120);
+      this.prevMean = this.mean;
+      this.meanTarget = rnd(-1.9, 0.7);
+    }
+    this.mean = lerp(this.prevMean, this.meanTarget, smoothstep(this.meanTimer / this.meanDuration));
+    const dv = this.theta * (this.mean - this.speed) * dt + this.sigma * Math.sqrt(dt) * gaussianRandom();
+    this.speed = clamp(this.speed + dv, -3.2, 3.2);
+  },
+};
+function rainIntensityMMHR(t) {
+  const n = noise1D(t * 0.007 + 900);
+  return clamp(lerp(2.5, 12.5, (n + 1) / 2), 2.5, 12.5); // mm/hr
+}
+
+// ── Drop-size sampling (Marshall–Palmer) ────────────────────────────────
+function sampleDiameterMM(lambda) {
+  const u = Math.random();
+  let d = -Math.log(1 - u) / lambda;
+  if (d < 0.16) d = 0.16 + Math.random() * 0.05;
+  if (d > 5.5) d = 5.5 - Math.random() * 0.4; // real drops break up past ~5-6mm
+  return d;
+}
+function terminalVelocityMS(D) {
+  const small = 0.27 * Math.pow(D / 0.1, 1.15);
+  const large = Math.min(3.778 * Math.pow(Math.max(D, 0.001), 0.67), 9.5);
+  if (D >= 1.15) return large;
+  if (D <= 0.85) return small;
+  return lerp(small, large, (D - 0.85) / 0.30);
+}
+
+// ── Drops ────────────────────────────────────────────────────────────────
+let currentLambda = 3.0;
+function layerZ(layer) {
+  if (layer === 'far') return rnd(0, 0.33);
+  if (layer === 'mid') return rnd(0.33, 0.66);
+  return rnd(0.66, 1);
+}
+
+class Drop {
+  constructor(layer) { this.layer = layer; this.reset(true); }
+
+  reset(initial) {
+    this.z = layerZ(this.layer);
+    this.D = sampleDiameterMM(currentLambda);
+    // Rare "hero" droplets — big, bright, deliberately uncommon, only in
+    // the foreground layer where they'll actually read as a focal detail.
+    if (this.layer === 'near' && Math.random() < 0.012) this.D = rnd(3.6, 5.4);
+
+    this.vt = terminalVelocityMS(this.D) * PPM;
+    // Small drops relax to wind fast and get deflected a bigger fraction
+    // of it (higher drag-to-mass ratio) — but gain is capped well under 1
+    // even at the extreme, so a drop can lean, never out-run its own fall
+    // speed sideways.
+    this.windRate = clamp(0.9 / this.D, 0.15, 4.5);
+    this.windGain = clamp(0.55 / this.D, 0.09, 0.30);
+    this.turbPhase = Math.random() * Math.PI * 2;
+    this.turbFreq = 0.6 + Math.random() * 1.2;
+
+    const colorObj = pickDropColorObj(this.z);
+    const depthFactor = lerp(0.6, 1.15, this.z);
+    this.thickness = clamp(this.D * 0.62 * depthFactor, 0.5, 3.6);
+    // Alpha ramps with size so the population reads as composed rather
+    // than uniform: lots of faint small streaks, fewer bright long ones,
+    // rare bright hero drops at the top of the curve.
+    this.alpha = clamp(lerp(0.13, 0.95, Math.min(1, this.D / 2.6)), 0.11, 0.97) * lerp(0.55, 1.0, this.z);
+    this.colorRGBA = rgba(colorObj, this.alpha);
+
+    this.x = rnd(-120, W + 120);
+    this.y = initial ? rnd(-H * 0.6, H * 1.05) : rnd(-60, -6);
+    this.vx = 0;
+    this.vy = initial ? rnd(0, this.vt) : 0;
+  }
+
+  groundY() { return H - 6 - (1 - this.z) * 16; }
+  offscreen() { return this.x < -220 || this.x > W + 220 || this.y > H + 80; }
+
+  update(dt, wind_px, t) {
+    const rel = this.vt > 0 ? this.vy / this.vt : 0;
+    this.vy += GRAVITY_PX * (1 - rel * rel) * dt;
+    if (this.vy < 0) this.vy = 0;
+
+    const targetVx = wind_px * this.windGain;
+    this.vx += (targetVx - this.vx) * this.windRate * dt;
+    this.vx += Math.sin(t * this.turbFreq + this.turbPhase) * 7 * this.windGain * dt;
+
+    this.x += this.vx * dt;
+    this.y += this.vy * dt;
+  }
+
+  draw(targetCtx, prominence) {
+    const speed = Math.hypot(this.vx, this.vy) || 1;
+    const nx = this.vx / speed, ny = this.vy / speed;
+    const len = clamp((this.D * 2.0 + speed * 0.03) * prominence, 6, 60);
+    targetCtx.strokeStyle = this.colorRGBA;
+    targetCtx.lineWidth = this.thickness * prominence;
+    targetCtx.lineCap = 'round';
+    targetCtx.beginPath();
+    targetCtx.moveTo(this.x, this.y);
+    targetCtx.lineTo(this.x - nx * len, this.y - ny * len);
+    targetCtx.stroke();
+  }
+}
+
+const layers = { far: [], mid: [], near: [] };
+const LAYER_SHARE = { far: 0.42, mid: 0.33, near: 0.25 };
+const LAYER_PROMINENCE = { far: 0.9, mid: 1.0, near: 1.32 };
+
+function updateLayer(name, target, dt, wind_px, t, targetCtx) {
+  const arr = layers[name];
+  const prominence = LAYER_PROMINENCE[name];
+  while (arr.length < target) arr.push(new Drop(name));
+
+  for (let i = arr.length - 1; i >= 0; i--) {
+    const d = arr[i];
+    d.update(dt, wind_px, t);
+
+    if (d.y >= d.groundY()) {
+      spawnSplash(d, wind_px);
+      if (arr.length > target) { arr.splice(i, 1); continue; }
+      d.reset(false);
+    } else if (d.offscreen()) {
+      if (arr.length > target) { arr.splice(i, 1); continue; }
+      d.reset(false);
+    }
+    d.draw(targetCtx, prominence);
+  }
+}
+
+// ── Splash / impact particles ───────────────────────────────────────────
+const particles = [];
+
+function spawnSplash(drop, wind_px) {
+  const x = drop.x, y = drop.groundY(), D = drop.D;
+  const v_ms = drop.vy / PPM;
+  const colorObj = pickDropColorObj(Math.min(1, drop.z + 0.15));
+  const leeward = drop.vx >= 0 ? 1 : -1;
+  const leewardStrength = clamp(Math.abs(drop.vx) / 260, 0, 1);
+
+  if (D < 0.26) {
+    if (Math.random() < 0.25) {
+      particles.push({ kind: 'mist', x, y, vx: rnd(-8, 8), vy: -rnd(2, 12),
+        r: rnd(0.4, 1.0), colorBase: colorObj, alpha: rnd(0.03, 0.07), decay: rnd(1.0, 2.0), life: 1 });
+    }
+    return;
+  }
+
+  const massRel = Math.pow(D, 3);
+  const energyRel = 0.5 * massRel * v_ms * v_ms;
+  const splashScale = clamp(Math.pow(energyRel, 0.2), 0.22, 3.0);
+
+  // Asymmetric crown: oblique-impact splash research shows the crown and
+  // its ligaments form preferentially on the leeward side, with just a
+  // swell on the windward side — so the ripple centre nudges downwind and
+  // stretches along the direction of travel instead of a perfect circle.
+  const maxR = clamp(splashScale * 3.0, 1.5, 9.5);
+  particles.push({
+    kind: 'ripple', x: x + leeward * leewardStrength * maxR * 0.28, y, colorBase: colorObj,
+    r: 0.4, maxR,
+    aspect: clamp(0.22 + leewardStrength * 0.14 + Math.random() * 0.08, 0.2, 0.5),
+    rot: leeward * leewardStrength * 0.5,
+    alpha: clamp(0.05 + splashScale * 0.05, 0.05, 0.26),
+    decay: rnd(1.5, 3.4), life: 1,
+  });
+
+  // Occasional leeward ligament ticks — the crown rim breaking into short
+  // fingers — only for impacts with enough energy, and not every time.
+  if (D > 1.3 && Math.random() < 0.4) {
+    const nt = Math.round(rnd(2, 4));
+    for (let i = 0; i < nt; i++) {
+      const a = -Math.PI / 2 + leeward * rnd(0.15, 0.75);
+      particles.push({ kind: 'tick', x, y, colorBase: colorObj, ang: a,
+        len: rnd(2.5, 5.5) * splashScale, alpha: clamp(0.10 + splashScale * 0.08, 0.08, 0.3),
+        decay: rnd(2.2, 4.0), life: 1 });
+    }
+  }
+
+  // Secondary droplets, biased leeward; count varies (sometimes none) so
+  // impacts don't all look identical.
+  const n = Math.random() < 0.18 ? 0 : Math.round(clamp(splashScale * rnd(0.9, 2.0), 0, 6));
+  for (let i = 0; i < n; i++) {
+    const ang = -Math.PI / 2 + leeward * rnd(0.1, 0.55) + rnd(-0.3, 0.3);
+    const spd = rnd(6, 13 + splashScale * 20);
+    particles.push({ kind: 'drop', x, y, colorBase: colorObj,
+      vx: Math.cos(ang) * spd + drop.vx * 0.15, vy: Math.sin(ang) * spd - rnd(3, 12),
+      size: clamp(splashScale * rnd(0.35, 0.9), 0.3, 1.8),
+      alpha: clamp(0.16 + splashScale * 0.12, 0.14, 0.5), decay: rnd(2.5, 5.5), life: 1 });
+  }
+
+  if (D < 2.2 && Math.random() < 0.4) {
+    particles.push({ kind: 'mist', x: x + rnd(-4, 4), y: y - rnd(0, 4),
+      vx: wind_px * 0.15 + rnd(-7, 7), vy: -rnd(2, 9), r: rnd(1, 2.6),
+      colorBase: PALETTE.light, alpha: rnd(0.02, 0.06), decay: rnd(1.0, 2.2), life: 1 });
+  }
+
+  RainEvents.emit('splash', { x, y, D, impactSpeed: v_ms, intensity: splashScale });
+}
+
+function updateParticles(dt, wind_px) {
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const s = particles[i];
+    s.life -= s.decay * dt;
+    if (s.life <= 0) { particles.splice(i, 1); continue; }
+    const a = clamp(s.alpha * s.life, 0, 1);
+
+    if (s.kind === 'ripple') {
+      const progress = s.r / s.maxR;
+      const rate = lerp(85, 16, smoothstep(progress));
+      s.r = Math.min(s.r + rate * dt, s.maxR);
+      const rr = Math.max(0, s.r);
+      ctx.strokeStyle = rgba(s.colorBase, a);
+      ctx.lineWidth = clamp(0.6 * s.life, 0.15, 0.8);
+      ctx.beginPath();
+      ctx.ellipse(s.x, s.y, rr, rr * s.aspect, s.rot, 0, Math.PI * 2);
+      ctx.stroke();
+    } else if (s.kind === 'tick') {
+      const l = s.len * (0.4 + 0.6 * s.life);
+      ctx.strokeStyle = rgba(s.colorBase, a);
+      ctx.lineWidth = 0.7;
+      ctx.beginPath();
+      ctx.moveTo(s.x, s.y);
+      ctx.lineTo(s.x + Math.cos(s.ang) * l, s.y + Math.sin(s.ang) * l);
+      ctx.stroke();
+    } else if (s.kind === 'drop') {
+      s.vy += GRAVITY_PX * 0.55 * dt;
+      s.vx = lerp(s.vx, wind_px * 0.25, 0.05);
+      s.x += s.vx * dt; s.y += s.vy * dt;
+      ctx.fillStyle = rgba(s.colorBase, a);
+      ctx.beginPath(); ctx.arc(s.x, s.y, s.size, 0, Math.PI * 2); ctx.fill();
+    } else if (s.kind === 'mist') {
+      s.x += s.vx * dt; s.y += s.vy * dt; s.vy *= 0.985;
+      ctx.fillStyle = rgba(s.colorBase, a);
+      ctx.beginPath(); ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2); ctx.fill();
+    }
+  }
+}
+
+// ── Atmospheric ground haze (restrained) ────────────────────────────────
+const mistBands = [];
+function spawnMistBand() {
+  return { x: rnd(-140, W + 140), y: H - rnd(0, 30), w: rnd(60, 170), h: rnd(3, 10),
+    alpha: rnd(0.010, 0.038), vx: rnd(-3, 3), life: 1, decay: rnd(0.14, 0.32) };
+}
+function initMist() { for (let i = 0; i < 7; i++) { const m = spawnMistBand(); m.life = rnd(0.1, 1); mistBands.push(m); } }
+function updateMist(dt, wind_px) {
+  if (mistBands.length < 9 && Math.random() < dt * 0.5) mistBands.push(spawnMistBand());
+  for (let i = mistBands.length - 1; i >= 0; i--) {
+    const m = mistBands[i];
+    m.vx = lerp(m.vx, wind_px * 0.3, 0.01);
+    m.x += m.vx * dt;
+    m.life -= m.decay * dt;
+    if (m.life <= 0) { mistBands.splice(i, 1); continue; }
+    ctx.fillStyle = rgba(PALETTE.light, m.alpha * smoothstep(m.life));
+    ctx.beginPath();
+    ctx.ellipse(m.x, m.y, m.w * 0.5, m.h * 0.5, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+// ── Background, cloud light, ground sheen, bokeh, vignette, glass sheen ─
+// The page background is transparent (see <style>) so Bonjourr's real
+// background shows through this overlay — the canvas only clearRects it,
+// no opaque fill is painted here.
+// Vignette + glass sheen never change shape between resizes, so they're
+// pre-rendered once to an offscreen canvas and blitted (one cheap
+// drawImage) instead of re-rasterizing two full-canvas gradients every
+// frame — gradient fills, not just blur, turned out to be the bigger
+// cost at large (ultrawide) canvas sizes in testing.
+let overlayCanvas, overlayCtx;
+function buildStaticOverlay() {
+  if (!overlayCanvas) { overlayCanvas = document.createElement('canvas'); overlayCtx = overlayCanvas.getContext('2d'); }
+  overlayCanvas.width = W; overlayCanvas.height = H;
+  overlayCtx.setTransform(1, 0, 0, 1, 0, 0);
+  overlayCtx.clearRect(0, 0, W, H);
+
+  const R = Math.max(W, H) * 0.68;
+  const vignetteGradient = overlayCtx.createRadialGradient(0, 0, 0.22 * R, 0, 0, R);
+  vignetteGradient.addColorStop(0, 'rgba(0,0,0,0)');
+  vignetteGradient.addColorStop(1, 'rgba(0,0,0,0.42)');
+  overlayCtx.save();
+  overlayCtx.translate(W / 2, H / 2);
+  overlayCtx.fillStyle = vignetteGradient;
+  overlayCtx.fillRect(-R, -R, R * 2, R * 2);
+  overlayCtx.restore();
+
+  const glassSheenGradient = overlayCtx.createLinearGradient(0, 0, W * 0.6, H);
+  glassSheenGradient.addColorStop(0, 'rgba(200,215,235,0.035)');
+  glassSheenGradient.addColorStop(0.15, 'rgba(200,215,235,0.012)');
+  glassSheenGradient.addColorStop(0.35, 'rgba(200,215,235,0)');
+  glassSheenGradient.addColorStop(1, 'rgba(200,215,235,0)');
+  overlayCtx.fillStyle = glassSheenGradient;
+  overlayCtx.fillRect(0, 0, W, H);
+}
+function drawBackground() { ctx.clearRect(0, 0, W, H); }
+function drawStaticOverlay() { ctx.drawImage(overlayCanvas, 0, 0, W, H); }
+
+// Soft diffuse backlight suggesting moonlight through cloud cover — drifts
+// extremely slowly, so it's re-rasterized to a small offscreen canvas only
+// occasionally and blitted (scaled) every frame in between, rather than
+// re-evaluating a full-canvas radial gradient 60 times a second for
+// something that barely moves.
+const cloudLight = { xFrac: 0.42, yFrac: 0.26, phase: rnd(0, 10) };
+let cloudCanvas, cloudCtx, cloudRefreshTimer = 0;
+function refreshCloudLight(t) {
+  if (!cloudCanvas) { cloudCanvas = document.createElement('canvas'); cloudCtx = cloudCanvas.getContext('2d'); }
+  const cw = Math.max(1, Math.round(W * 0.25)), ch = Math.max(1, Math.round(H * 0.25));
+  if (cloudCanvas.width !== cw) cloudCanvas.width = cw;
+  if (cloudCanvas.height !== ch) cloudCanvas.height = ch;
+  cloudCtx.clearRect(0, 0, cw, ch);
+  const cx = (cloudLight.xFrac * W + Math.sin(t * 0.004 + cloudLight.phase) * W * 0.08) * 0.25;
+  const cy = (cloudLight.yFrac * H + Math.cos(t * 0.003 + cloudLight.phase) * H * 0.05) * 0.25;
+  const r = Math.max(W, H) * 0.55 * 0.25;
+  const g = cloudCtx.createRadialGradient(cx, cy, 0, cx, cy, r);
+  g.addColorStop(0, 'rgba(120,135,165,0.05)');
+  g.addColorStop(0.5, 'rgba(90,105,140,0.024)');
+  g.addColorStop(1, 'rgba(90,105,140,0)');
+  cloudCtx.fillStyle = g;
+  cloudCtx.fillRect(0, 0, cw, ch);
+}
+function drawCloudLight(t, dt) {
+  cloudRefreshTimer += dt;
+  if (!cloudCanvas || cloudRefreshTimer > 0.18) { cloudRefreshTimer = 0; refreshCloudLight(t); }
+  ctx.drawImage(cloudCanvas, 0, 0, W, H);
+}
+
+function drawGroundSheen() {
+  const py = H - 6;
+  const g = ctx.createLinearGradient(0, py - 10, 0, py + 6);
+  g.addColorStop(0, 'rgba(130,155,190,0)');
+  g.addColorStop(0.5, 'rgba(110,140,180,0.09)');
+  g.addColorStop(1, 'rgba(90,120,165,0.04)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, py - 10, W, 16);
+}
+
+let bokehLights = [];
+function drawBokeh(t) {
+  for (const b of bokehLights) {
+    const bx = b.xFrac * W + Math.sin(t * 0.015 + b.phase) * 18;
+    const by = b.yFrac * H + Math.cos(t * 0.011 + b.phase) * 8;
+    const flicker = 0.85 + 0.15 * Math.sin(t * 0.6 + b.phase * 3);
+    const alpha = 0.055 * flicker;
+    const rgbStr = b.warm ? '255,214,170' : '190,205,225';
+    const g = ctx.createRadialGradient(bx, by, 0, bx, by, b.r);
+    g.addColorStop(0, `rgba(${rgbStr},${alpha})`);
+    g.addColorStop(1, `rgba(${rgbStr},0)`);
+    ctx.fillStyle = g;
+    ctx.fillRect(bx - b.r, by - b.r, b.r * 2, b.r * 2);
+  }
+}
+
+// ── Foreground window glass: slower, fewer, better-lit condensation ────
+class GlassDrop {
+  constructor() { this.reset(true); }
+  reset(initial) {
+    this.x = rnd(W * 0.06, W * 0.94);
+    this.y = initial ? rnd(-H * 0.3, H * 0.5) : rnd(-40, -6);
+    this.v = rnd(1.2, 3.4);
+    this.r = rnd(1.5, 3.1);
+    this.stickTimer = rnd(0.6, 3.0);
+    this.trail = [];
+    this.alpha = rnd(0.09, 0.17);
+    this.colorObj = Math.random() < 0.5 ? PALETTE.light : PALETTE.offwhite;
+  }
+  update(dt) {
+    this.stickTimer -= dt;
+    if (this.stickTimer <= 0) { this.v += rnd(7, 24); this.stickTimer = rnd(0.7, 3.4); }
+    this.v = lerp(this.v, rnd(1.6, 4.2), 0.02);
+    this.y += this.v * dt;
+    this.x += Math.sin(this.y * 0.017) * 1.4 * dt;
+    // Trail points are sampled by distance travelled, not by frame — at a
+    // slow ~1-4px/s crawl, one point per frame only spans a fraction of a
+    // pixel of history and reads as a dot, not a trail.
+    const last = this.trail[this.trail.length - 1];
+    if (!last || Math.hypot(this.x - last.x, this.y - last.y) > 1.4) {
+      this.trail.push({ x: this.x, y: this.y });
+      if (this.trail.length > 26) this.trail.shift();
+    }
+    if (this.y > H + 20) this.reset(false);
+  }
+  draw() {
+    const a = this.alpha;
+    if (this.trail.length > 1) {
+      const t0 = this.trail[0];
+      const grad = ctx.createLinearGradient(t0.x, t0.y, this.x, this.y);
+      grad.addColorStop(0, rgba(this.colorObj, 0));
+      grad.addColorStop(1, rgba(this.colorObj, a * 0.4));
+      ctx.strokeStyle = grad;
+      ctx.lineWidth = this.r * 0.48;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(t0.x, t0.y);
+      for (const p of this.trail) ctx.lineTo(p.x, p.y);
+      ctx.stroke();
+    }
+    // Specular highlight + faint refractive rim, alpha pre-baked into each
+    // gradient stop so no ctx.globalAlpha state is needed at all.
+    const g = ctx.createRadialGradient(this.x - this.r * 0.35, this.y - this.r * 0.35, 0, this.x, this.y, this.r);
+    g.addColorStop(0, `rgba(255,255,255,${(0.95 * a).toFixed(3)})`);
+    g.addColorStop(0.32, rgba(this.colorObj, 0.9 * a));
+    g.addColorStop(0.78, rgba({ r: 60, g: 70, b: 88 }, 0.35 * a));
+    g.addColorStop(1, 'rgba(255,255,255,0)');
+    ctx.fillStyle = g;
+    ctx.beginPath(); ctx.arc(this.x, this.y, this.r, 0, Math.PI * 2); ctx.fill();
+  }
+}
+let glassDrops = [];
+
+// ── Responsive art direction ────────────────────────────────────────────
+// Adapts composition (density, bokeh count, glass count), not just canvas
+// scale, to phone / laptop / ultrawide aspect ratios.
+let sceneParams = {};
+function computeSceneParams() {
+  const area = W * H;
+  const aspect = W / H;
+  sceneParams = {
+    areaFactor: clamp(area / (1280 * 720), 0.4, 1.8),
+    classDensity: aspect > 2.05 ? 0.80 : aspect < 0.8 ? 0.90 : 1.0,
+    bokehCount: aspect > 2.0 ? 6 : aspect < 0.8 ? 2 : 4,
+    glassCount: Math.round(clamp(3 + area / 900000, 3, 6)),
+  };
+}
+function rebuildResponsiveActors() {
+  bokehLights = Array.from({ length: sceneParams.bokehCount }, (_, i) => ({
+    xFrac: rnd(0.05, 0.95), yFrac: rnd(0.12, 0.48), r: rnd(30, 70), warm: Math.random() < 0.5, phase: rnd(0, 10) + i,
+  }));
+  glassDrops = Array.from({ length: sceneParams.glassCount }, () => new GlassDrop());
+}
+
+// ── Resize / init ────────────────────────────────────────────────────────
+function resize() {
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  W = window.innerWidth; H = window.innerHeight;
+  canvas.width = Math.round(W * dpr); canvas.height = Math.round(H * dpr);
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+  if (!farCanvas) { farCanvas = document.createElement('canvas'); farCtx = farCanvas.getContext('2d'); }
+  farCanvas.width = Math.max(1, Math.round(W * 0.5));
+  farCanvas.height = Math.max(1, Math.round(H * 0.5));
+  farCtx.setTransform(0.5, 0, 0, 0.5, 0, 0);
+
+  buildStaticOverlay();
+  computeSceneParams();
+  rebuildResponsiveActors();
+}
+window.addEventListener('resize', resize);
+
+// ── Main loop ────────────────────────────────────────────────────────────
+let last = performance.now();
+let simTime = 0;
+let ambientEventTimer = 0;
+
+function tick(now) {
+  requestAnimationFrame(tick);
+  let dt = (now - last) / 1000;
+  last = now;
+  dt = Math.max(0, Math.min(dt, 0.05));
+  simTime += dt;
+
+  Wind.update(dt);
+  const windMS = Wind.speed;
+  const wind_px = windMS * PPM;
+  const rainRate = rainIntensityMMHR(simTime);
+  currentLambda = 4.1 * Math.pow(rainRate, -0.21);
+
+  const targetTotal = Math.round(lerp(190, 480, (rainRate - 2.5) / 10) * sceneParams.areaFactor * sceneParams.classDensity);
+  const targets = {
+    far: Math.round(targetTotal * LAYER_SHARE.far),
+    mid: Math.round(targetTotal * LAYER_SHARE.mid),
+    near: Math.round(targetTotal * LAYER_SHARE.near),
+  };
+
+  drawBackground();
+  drawCloudLight(simTime, dt);
+  drawBokeh(simTime);
+  updateMist(dt, wind_px);
+
+  // Far layer: draw to a half-res offscreen canvas, then composite once.
+  // The half-res -> full-res upscale already does a free bilinear soften;
+  // an explicit ctx.filter blur pass roughly doubled frame cost in testing
+  // for a marginal extra softness, so it's skipped — cheap depth cue over
+  // an expensive one, per the same efficiency trade-off real-time rain
+  // renderers in the literature make.
+  farCtx.clearRect(0, 0, W, H);
+  updateLayer('far', targets.far, dt, wind_px, simTime, farCtx);
+  ctx.drawImage(farCanvas, 0, 0, W, H);
+
+  updateLayer('mid', targets.mid, dt, wind_px, simTime, ctx);
+  updateLayer('near', targets.near, dt, wind_px, simTime, ctx);
+
+  updateParticles(dt, wind_px);
+  drawGroundSheen();
+  drawStaticOverlay();
+
+  for (const g of glassDrops) { g.update(dt); g.draw(); }
+
+  ambientEventTimer += dt;
+  if (ambientEventTimer > 1.2) {
+    ambientEventTimer = 0;
+    RainEvents.emit('ambient', { rainRateMMHR: rainRate, windMS });
+  }
+}
+
+resize();
+initMist();
+requestAnimationFrame(tick);

--- a/src/index.html
+++ b/src/index.html
@@ -319,8 +319,7 @@
                             <svg class="contextmenu-icon" aria-hidden="true">
                                 <use
                                     href="src/assets/interface/contextmenu-sprites.svg#contextmenu-background-download"
-                                >
-                                </use>
+                                ></use>
                             </svg>
                         </span>
 
@@ -373,8 +372,8 @@
                     >
                         <span class="iconContainer">
                             <svg class="contextmenu-icon" aria-hidden="true">
-                                <use href="src/assets/interface/contextmenu-sprites.svg#contextmenu-background-refresh">
-                                </use>
+                                <use
+                                    href="src/assets/interface/contextmenu-sprites.svg#contextmenu-background-refresh"></use>
                             </svg>
                         </span>
                         <span class="trn">Next background</span>
@@ -465,9 +464,16 @@
             </div>
         </dialog>
 
-        <div id="background-wrapper" class="hidden" data-type="images" data-texture="none">
+        <div id="background-wrapper" class="hidden" data-type="images" data-texture="none" data-effect="none">
             <div id="background-media"></div>
             <div id="background-color"></div>
+            <iframe
+                id="background-effect"
+                title="Background effect"
+                sandbox="allow-scripts"
+                tabindex="-1"
+                aria-hidden="true"
+            ></iframe>
             <div id="background-texture"></div>
         </div>
 
@@ -616,8 +622,7 @@
                         >
                             <path
                                 d="M73 39c-14.8-9.1-33.4-9.4-48.5-.9S0 62.6 0 80L0 432c0 17.4 9.4 33.4 24.5 41.9s33.7 8.1 48.5-.9L361 297c14.3-8.7 23-24.2 23-41s-8.7-32.2-23-41L73 39z"
-                            >
-                            </path>
+                            ></path>
                         </svg>
                     </button>
 
@@ -630,8 +635,7 @@
                         >
                             <path
                                 d="M48 64C21.5 64 0 85.5 0 112L0 400c0 26.5 21.5 48 48 48l32 0c26.5 0 48-21.5 48-48l0-288c0-26.5-21.5-48-48-48L48 64zm192 0c-26.5 0-48 21.5-48 48l0 288c0 26.5 21.5 48 48 48l32 0c26.5 0 48-21.5 48-48l0-288c0-26.5-21.5-48-48-48l-32 0z"
-                            >
-                            </path>
+                            ></path>
                         </svg>
                     </button>
 
@@ -672,6 +676,30 @@
                 <p id="author"></p>
             </div>
         </main>
+
+        <div id="scribble_container" class="hidden">
+            <div id="scribble_handle">
+                <button id="scribble_pencil" aria-label="Toggle doodle mode" title="Doodle">✎</button>
+                <div id="scribble_handle-actions">
+                    <button id="scribble_clear" aria-label="Clear doodle" title="Clear doodle">⟲</button>
+                    <button id="scribble_close" aria-label="Close scribble pad" title="Close">✕</button>
+                </div>
+            </div>
+
+            <div id="scribble_stage">
+                <div id="scribble_write"></div>
+                <canvas id="scribble_draw"></canvas>
+            </div>
+
+            <div class="scribble_resize" data-dir="n"></div>
+            <div class="scribble_resize" data-dir="s"></div>
+            <div class="scribble_resize" data-dir="e"></div>
+            <div class="scribble_resize" data-dir="w"></div>
+            <div class="scribble_resize" data-dir="ne"></div>
+            <div class="scribble_resize" data-dir="nw"></div>
+            <div class="scribble_resize" data-dir="se"></div>
+            <div class="scribble_resize" data-dir="sw"></div>
+        </div>
 
         <div id="credit-container">
             <div id="credit"></div>
@@ -756,7 +784,7 @@
                 <li class="link link-elem">
                     <a rel="noreferrer noopener" draggable="false">
                         <div class="link-icon">
-                            <img alt="" draggable="false" />
+                            <img alt="" draggable="false" decoding="async" />
                         </div>
                         <span class="link-elem-title"></span>
                     </a>
@@ -766,10 +794,10 @@
             <template id="link-folder-template">
                 <li class="link link-folder" tabindex="0">
                     <div class="link-icon">
-                        <img alt="" draggable="false" />
-                        <img alt="" draggable="false" />
-                        <img alt="" draggable="false" />
-                        <img alt="" draggable="false" />
+                        <img alt="" draggable="false" decoding="async" />
+                        <img alt="" draggable="false" decoding="async" />
+                        <img alt="" draggable="false" decoding="async" />
+                        <img alt="" draggable="false" decoding="async" />
                     </div>
 
                     <span class="link-elem-title"></span>
@@ -878,62 +906,62 @@
 
             <!-- help-mode -->
             <style>
-                #help-mode-prompt {
-                    position: fixed;
-                    top: 40vh;
-                    left: 0;
-                    right: 0;
-                    color: #eeeeee;
-                    font-family: system-ui;
-                    font-size: 1em;
-                    text-align: center;
-                    z-index: 1;
-                }
+            #help-mode-prompt {
+                position: fixed;
+                top: 40vh;
+                left: 0;
+                right: 0;
+                color: #eeeeee;
+                font-family: system-ui;
+                font-size: 1em;
+                text-align: center;
+                z-index: 1;
+            }
 
-                #help-mode-prompt h1 {
-                    margin-bottom: 0;
-                }
+            #help-mode-prompt h1 {
+                margin-bottom: 0;
+            }
 
-                #help-mode-prompt p {
-                    margin-top: 0.5em;
-                }
+            #help-mode-prompt p {
+                margin-top: 0.5em;
+            }
 
-                #help-buttons {
-                    margin-top: 1.5em;
-                    display: flex;
-                    justify-content: center;
-                    gap: 1em;
-                }
+            #help-buttons {
+                margin-top: 1.5em;
+                display: flex;
+                justify-content: center;
+                gap: 1em;
+            }
 
-                .help-btn {
-                    cursor: pointer;
-                    height: 31px;
-                    padding: 0 1em;
-                    color: rgb(var(--accent-color));
-                    border: none;
-                    border-radius: 1em;
-                    white-space: nowrap;
-                    background-color: rgb(var(--accent-color) / 0.25);
-                    display: inline-flex;
-                    justify-content: center;
-                    align-items: center;
-                    gap: 5px;
-                }
+            .help-btn {
+                cursor: pointer;
+                height: 31px;
+                padding: 0 1em;
+                color: rgb(var(--accent-color));
+                border: none;
+                border-radius: 1em;
+                white-space: nowrap;
+                background-color: rgb(var(--accent-color) / 0.25);
+                display: inline-flex;
+                justify-content: center;
+                align-items: center;
+                gap: 5px;
+            }
 
-                .help-btn:hover {
-                    background-color: rgb(var(--accent-color) / 0.35);
-                }
+            .help-btn:hover {
+                background-color: rgb(var(--accent-color) / 0.35);
+            }
 
-                .help-btn[disabled] {
-                    color: #777777;
-                    background-color: #282828;
-                    cursor: not-allowed;
-                }
+            .help-btn[disabled] {
+                color: #777777;
+                background-color: #282828;
+                cursor: not-allowed;
+            }
 
-                .help-btn.danger:hover {
-                    color: rgb(var(--danger-color));
-                    background-color: rgb(var(--danger-color) / 0.25);
-                }
+            .help-btn.danger:hover {
+                color: rgb(var(--danger-color));
+                background-color: rgb(var(--danger-color) / 0.25);
+            }
             </style>
         </div>
     </body>

--- a/src/scripts/defaults.ts
+++ b/src/scripts/defaults.ts
@@ -133,6 +133,7 @@ export const SYNC_DEFAULT: Sync = {
     },
     backgrounds: {
         type: 'images',
+        effect: 'none',
         fadein: 600,
         blur: 15,
         bright: 0.8,
@@ -186,6 +187,11 @@ export const SYNC_DEFAULT: Sync = {
         width: 40,
         opacity: 0.1,
         align: 'left',
+    },
+    scribble: {
+        on: false,
+        draw: false,
+        text: '',
     },
     searchbar: {
         on: false,
@@ -248,4 +254,7 @@ export const LOCAL_DEFAULT: Local = {
     backgroundCompressFiles: true,
     backgroundLastChange: '',
     lastWeather: undefined,
+    scribblePosition: undefined,
+    scribbleSize: undefined,
+    scribbleDrawing: '',
 }

--- a/src/scripts/features/backgrounds/VideoLooper.ts
+++ b/src/scripts/features/backgrounds/VideoLooper.ts
@@ -84,14 +84,28 @@ export class VideoLooper {
             this.video1.remove()
             this.video2.remove()
             this.container.remove()
-
-            if (this.listener) {
-                document.removeEventListener(
-                    'visibilitychange',
-                    this.listener,
-                )
-            }
+            this.unbindVisibilityListener()
         }, this.fadetime)
+    }
+
+    /**
+     * Detaches the `document`-level 'visibilitychange' listener without
+     * touching opacity or the DOM. Call this (instead of `remove()`) when
+     * another piece of code already owns this instance's container removal
+     * / crossfade timing -- eg. replacing the active video background,
+     * where `applyBackground()`'s own crossfade handles fading out and
+     * detaching the old container. Without unbinding this, the listener
+     * (and everything it closes over: both <video> elements and their
+     * blob-backed src) stays reachable from `document` forever, even after
+     * the container itself is long gone from the page.
+     */
+    public unbindVisibilityListener(): void {
+        if (this.listener) {
+            document.removeEventListener(
+                'visibilitychange',
+                this.listener,
+            )
+        }
     }
 
     public getContainer(): HTMLElement {

--- a/src/scripts/features/backgrounds/index.ts
+++ b/src/scripts/features/backgrounds/index.ts
@@ -5,6 +5,7 @@ import { TEXTURE_RANGES } from './textures.ts'
 import { PROVIDERS } from './providers.ts'
 import {
     addLocalBackgrounds,
+    getCurrentVideo,
     initFilesSettingsOptions,
     lastUsedBackgroundFiles,
     localFilesCacheControl,
@@ -38,6 +39,7 @@ interface CollectionSetReturn {
 interface BackgroundUpdate {
     freq?: string
     type?: string
+    effect?: string
     blur?: string
     blurenter?: true
     color?: string
@@ -91,9 +93,17 @@ export function backgroundsInit(sync: Sync, local: Local, init?: true): void {
     handleBackgroundActions(sync.backgrounds)
     document.getElementById('background-wrapper')?.setAttribute('data-type', sync.backgrounds.type)
 
+    // <!> The fireflies/rain effect is a layer on top of whatever the real
+    // <!> background type is (photo, video, color...), not a type of its
+    // <!> own -- `applyEffectBackground` mounts or tears down its iframe
+    // <!> purely based on `effect`, independent of the switch below.
+    applyEffectBackground(sync.backgrounds.effect)
+
     switch (sync.backgrounds.type) {
         case 'files': {
-            localFilesCacheControl(sync.backgrounds, local)
+            localFilesCacheControl(sync.backgrounds, local).catch((err) =>
+                console.error('Bonjourr: local background init failed', err)
+            )
             break
         }
         case 'urls': {
@@ -101,18 +111,37 @@ export function backgroundsInit(sync: Sync, local: Local, init?: true): void {
             break
         }
         case 'color': {
-            applyBackground(sync.backgrounds.color)
+            applyBackground(sync.backgrounds.color).catch((err) =>
+                console.error('Bonjourr: background init failed', err)
+            )
             break
         }
         default: {
-            backgroundCacheControl(sync.backgrounds, local)
+            backgroundCacheControl(sync.backgrounds, local).catch((err) =>
+                console.error('Bonjourr: background init failed', err)
+            )
         }
     }
 }
 
 // 	Storage update
 
+// <!> `backgroundUpdate` is called fire-and-forget from ~20 call sites
+// <!> across settings.ts and contextmenu.ts (every background-related
+// <!> settings input, plus the context menu's pause/download/mute
+// <!> buttons) -- none of them await or catch it. It also does real I/O
+// <!> that can fail (file uploads, network image fetches, cache reads).
+// <!> Catching at this single choke point is far more reliable than
+// <!> hunting down and fixing every call site individually.
 export async function backgroundUpdate(update: BackgroundUpdate): Promise<void> {
+    try {
+        await backgroundUpdateUnsafe(update)
+    } catch (err) {
+        console.error('Bonjourr: failed to update background', err)
+    }
+}
+
+async function backgroundUpdateUnsafe(update: BackgroundUpdate): Promise<void> {
     const data = await storage.sync.get('backgrounds')
     const local = await storage.local.get()
 
@@ -146,6 +175,13 @@ export async function backgroundUpdate(update: BackgroundUpdate): Promise<void> 
         createProviderSelect(data.backgrounds)
         handleBackgroundOptions(data.backgrounds)
         backgroundsInit(data, local)
+        return
+    }
+
+    if (isBackgroundEffect(update.effect)) {
+        data.backgrounds.effect = update.effect
+        storage.sync.set({ backgrounds: data.backgrounds })
+        applyEffectBackground(data.backgrounds.effect)
         return
     }
 
@@ -622,14 +658,67 @@ function setCollection(backgrounds: Backgrounds, local: Local): CollectionSetRet
 
 // 	Apply to DOM
 
-export function applyBackground(media?: string | Background, res?: BackgroundSize, fast?: 'fast'): void {
+const IMAGE_DECODE_TIMEOUT_MS = 8000
+const VIDEO_PRELOAD_TIMEOUT_MS = 8000
+
+/**
+ * Waits for `img` to be fully decoded (off-main-thread) before resolving.
+ *
+ * <!> The `load`/`error` fallback listeners are attached *before* `src` is
+ * <!> set and before `decode()` is awaited. Attaching them only inside a
+ * <!> `.catch()` risks missing an event that already fired while `decode()`
+ * <!> was pending, which would silently hang the caller forever. A timeout
+ * <!> guarantees this never blocks a background swap indefinitely.
+ */
+async function decodeImage(img: HTMLImageElement, src: string): Promise<void> {
+    const loaded = new Promise<void>((resolve) => {
+        img.addEventListener('load', () => resolve(), { once: true })
+        img.addEventListener('error', () => resolve(), { once: true })
+    })
+
+    img.src = src
+
+    const timeout = new Promise<void>((resolve) => setTimeout(resolve, IMAGE_DECODE_TIMEOUT_MS))
+
+    try {
+        await Promise.race([img.decode(), timeout])
+    } catch (_err) {
+        await Promise.race([loaded, timeout])
+    }
+}
+
+// <!> `createImageItem`/`createVideoItem` background/video elements are
+// <!> backed by `URL.createObjectURL()` blobs (see `mediaFromFiles` in
+// <!> local.ts) that are never freed by themselves -- each one keeps its
+// <!> underlying image/video bytes alive in memory until explicitly
+// <!> revoked. Tagging the element with the URL it owns lets every removal
+// <!> site below revoke it at the exact moment the element is discarded,
+// <!> instead of leaking a blob on every single background switch.
+function revokeElementBlobUrl(el: Element | null | undefined): void {
+    const url = (el as HTMLElement | null)?.dataset?.blobSrc
+    if (url?.startsWith('blob:')) {
+        URL.revokeObjectURL(url)
+    }
+}
+
+export async function applyBackground(media?: string | Background, res?: BackgroundSize, fast?: 'fast'): Promise<void> {
     const mediaWrapper = document.getElementById('background-media') as HTMLDivElement
     let resolution = res ? res : detectBackgroundSize()
     let item: HTMLElement
 
     if (typeof media === 'string') {
-        mediaWrapper?.childNodes.forEach((node) => node.remove())
+        mediaWrapper?.childNodes.forEach((node) => {
+            revokeElementBlobUrl(node as Element)
+            node.remove()
+        })
         document.documentElement.style.setProperty('--solid-background', media)
+        // <!> createImageItem/createVideoItem unhide #background-wrapper as a
+        // <!> side effect once their media is ready. Solid colors have no such
+        // <!> async step, so without this the wrapper stays hidden (opacity 0,
+        // <!> pure black) whenever it wasn't already visible when the user
+        // <!> switches to (or starts on) a solid-color background -- eg. a
+        // <!> fresh install, or switching away from a still-loading image/video.
+        document.getElementById('background-wrapper')?.classList.remove('hidden')
         return
     }
 
@@ -641,18 +730,29 @@ export function applyBackground(media?: string | Background, res?: BackgroundSiz
         return
     }
 
+    let src: string
+
     if (media.format === 'image') {
         // disables blur compression for animated gifs (flawed since some gifs aren't animated)
         resolution = media.mimetype === 'image/gif' ? 'full' : resolution
-        const src = media.urls[resolution]
-        item = createImageItem(src, media)
+        src = media.urls[resolution]
+        // <!> This awaits full off-main-thread decode (img.decode()) before
+        // <!> the element ever touches the DOM. Setting `background-image`
+        // <!> synchronously and revealing it on the `load` event (bytes
+        // <!> arrived) used to force a main-thread JPEG/WebP decode at the
+        // <!> first paint, which is what caused the freeze.
+        item = await createImageItem(src, media)
     } else {
         const fade = 4000 //ms
-        const src = media.urls[resolution]
+        src = media.urls[resolution]
         item = createVideoItem(src, media, fade)
     }
 
     item.dataset.res = resolution
+    item.dataset.blobSrc = src
+    // <!> The crossfade below only starts once `item` is fully decoded
+    // <!> (image path) and already in the DOM, so the old background never
+    // <!> fades out ahead of the new one being ready to show.
     mediaWrapper.prepend(item)
 
     if (mediaWrapper?.childElementCount > 1) {
@@ -660,39 +760,41 @@ export function applyBackground(media?: string | Background, res?: BackgroundSiz
         const notHiding = children.filter((child) => !child.className.includes('hiding'))
         const lastVisible = notHiding.at(-1)
 
+        // <!> Capture the specific outgoing element now rather than
+        // <!> re-querying `lastElementChild` when the timeout fires. If
+        // <!> another background gets applied before this timeout runs,
+        // <!> "the last child" at that point could be a totally different,
+        // <!> freshly-added element, and this would remove that instead.
+        const outgoing = mediaWrapper?.lastElementChild
+
         if (fast) {
             document.body.classList.remove('init')
-            setTimeout(() => mediaWrapper?.lastElementChild?.remove(), 200)
+            setTimeout(() => {
+                revokeElementBlobUrl(outgoing)
+                outgoing?.remove()
+            }, 200)
         } else {
             lastVisible?.classList.add('hiding')
-            setTimeout(() => mediaWrapper?.lastElementChild?.remove(), 1200)
+            setTimeout(() => {
+                revokeElementBlobUrl(outgoing)
+                outgoing?.remove()
+            }, 1200)
         }
     }
 }
 
-function createImageItem(src: string, media: BackgroundImage, callback?: () => void): HTMLDivElement {
+async function createImageItem(src: string, media: BackgroundImage): Promise<HTMLDivElement> {
     const backgroundsWrapper = document.getElementById('background-wrapper')
     const div = document.createElement('div')
     const img = new Image()
 
-    img.addEventListener('load', () => {
-        const isSmall = img.width <= 256 && img.height <= 256
-        const isPng = !!media.mimetype?.includes('png')
+    await decodeImage(img, src)
 
-        div?.classList.toggle('pixelated', isPng && isSmall)
-        backgroundsWrapper?.classList.remove('hidden')
-        applyThemeColor(media, img)
-        updateCredits(media)
-
-        if (callback) {
-            callback()
-        }
-    })
-
-    img.src = src
-    img.remove()
+    const isSmall = img.width <= 256 && img.height <= 256
+    const isPng = !!media.mimetype?.includes('png')
 
     div.classList.add('background-image')
+    div.classList.toggle('pixelated', isPng && isSmall)
     div.style.backgroundImage = `url(${src})`
 
     if (media?.file?.position) {
@@ -702,6 +804,12 @@ function createImageItem(src: string, media: BackgroundImage, callback?: () => v
         div.style.backgroundPositionX = x
         div.style.backgroundPositionY = y
     }
+
+    backgroundsWrapper?.classList.remove('hidden')
+    applyThemeColor(media, img)
+    updateCredits(media)
+
+    img.remove()
 
     return div
 }
@@ -740,26 +848,44 @@ function preloadBackground(media: Background | undefined, res?: BackgroundSize):
         const img = document.createElement('img')
         img.fetchPriority = 'low'
 
-        return new Promise((resolve) => {
-            img.addEventListener('load', () => {
+        // <!> Preloading used to only wait for `load` (bytes fetched), so
+        // <!> decode still happened on the main thread later when the
+        // <!> image was actually applied. `img.decode()` fetches *and*
+        // <!> decodes off-main-thread, pre-warming the decode cache so the
+        // <!> later `createImageItem` call for this same `src` is instant.
+        return decodeImage(img, src)
+            .finally(() => {
                 localStorage.removeItem('backgroundPreloading')
                 img.remove()
-                resolve(true)
             })
-
-            img.src = src
-        })
+            .then(() => true)
     }
 
     if (media.format === 'video') {
         const video = document.createElement('video')
 
         return new Promise((resolve) => {
-            video.addEventListener('canplaythrough', () => {
+            const done = (): void => {
                 localStorage.removeItem('backgroundPreloading')
                 video.remove()
                 resolve(true)
-            })
+            }
+
+            // <!> No timeout/error handling here meant a video that fails to
+            // <!> buffer (bad codec, network hiccup) left `backgroundPreloading`
+            // <!> stuck at 'true' in localStorage forever, which the rest of
+            // <!> the background logic reads to decide whether to skip work.
+            const timeoutId = setTimeout(done, VIDEO_PRELOAD_TIMEOUT_MS)
+
+            video.addEventListener('canplaythrough', () => {
+                clearTimeout(timeoutId)
+                done()
+            }, { once: true })
+
+            video.addEventListener('error', () => {
+                clearTimeout(timeoutId)
+                done()
+            }, { once: true })
 
             // Wait the for applied video to continue buffering
             setTimeout(() => video.src = src, 600)
@@ -767,20 +893,114 @@ function preloadBackground(media: Background | undefined, res?: BackgroundSize):
     }
 }
 
+// 	Effect overlays ("fun lil effects": firefly, cozy rain)
+//
+// <!> These are a transparent layer drawn *on top of* whatever the real
+// <!> background type is (photo, video, or color) -- not a background type
+// <!> of their own. `applyEffectBackground` is called unconditionally from
+// <!> both `backgroundsInit` and the `effect` branch of `backgroundUpdate`,
+// <!> independent of `backgrounds.type`, and decides for itself whether to
+// <!> mount or tear down the iframe based on `effect` alone. Deliberately
+// <!> NOT routed through `applyBackground`'s crossfade/cache machinery --
+// <!> there's no `Background` item, collection, or resolution to fetch,
+// <!> cache-control, or preload here, just "which (if any) of the bundled
+// <!> animations is currently mounted."
+
+function applyEffectBackground(effect: Backgrounds['effect']): void {
+    const wrapper = document.getElementById('background-wrapper')
+    const iframe = document.getElementById('background-effect') as HTMLIFrameElement | null
+
+    if (!wrapper || !iframe) {
+        return
+    }
+
+    wrapper.dataset.effect = effect
+
+    // <!> These are full-viewport canvas animations -- exactly the kind of
+    // <!> CPU/GPU cost potato mode exists to avoid. CSS hides the iframe
+    // <!> under `body.potato` (see background.css), but skip mounting it
+    // <!> here too, so a potato-mode device never even starts the
+    // <!> animation loop in the first place.
+    const shouldMount = effect !== 'none' && !document.body.classList.contains('potato')
+
+    if (!shouldMount) {
+        // <!> Clearing `src` (not just hiding the element) is what actually
+        // <!> stops the iframe's own requestAnimationFrame loop and frees
+        // <!> its canvas -- an animation left running invisibly behind a
+        // <!> "None" selection or under potato mode would keep spending
+        // <!> CPU forever.
+        if (iframe.dataset.mounted) {
+            iframe.removeAttribute('src')
+            delete iframe.dataset.mounted
+        }
+        return
+    }
+
+    // Only reassign `src` (which restarts the animation from scratch) if
+    // the effect actually changed -- `applyEffectBackground` gets called
+    // again on things like a settings re-render, and there's no reason to
+    // reset an already-running scene just because of that.
+    if (iframe.dataset.mounted !== effect) {
+        iframe.dataset.mounted = effect
+        iframe.src = `src/assets/effects/${effect}.html`
+    }
+}
+
 export function removeBackgrounds(): void {
     const mediaWrapper = document.getElementById('background-media') as HTMLDivElement
-    setTimeout(() => document.querySelector('#background-media div')?.classList.add('hiding'))
-    setTimeout(() => mediaWrapper.firstChild?.remove(), 2000)
+    // <!> Capture the element to remove right now instead of re-querying
+    // <!> "the first child" 2 seconds later. Without this, calling
+    // <!> `removeBackgrounds()` (e.g. switching to an empty "Local files"
+    // <!> list) and then applying a new background within that 2s window
+    // <!> meant this stale timeout fired *after* the new background had
+    // <!> already been prepended, and deleted that instead -- the
+    // <!> wallpaper you just picked would flash and then silently vanish.
+    const outgoing = mediaWrapper?.firstElementChild
+
+    if (!outgoing) {
+        return
+    }
+
+    setTimeout(() => outgoing.classList.add('hiding'))
+    setTimeout(() => {
+        revokeElementBlobUrl(outgoing)
+        outgoing.remove()
+        // <!> Nothing else calls `setCurrentVideo()` after this (there's no
+        // <!> next background to replace it), so without this the previous
+        // <!> video's 'visibilitychange' listener -- and both its <video>
+        // <!> elements -- would stay reachable from `document` forever, even
+        // <!> though the container above was just removed from the page.
+        getCurrentVideo()?.unbindVisibilityListener()
+    }, 2000)
 }
+
+// <!> Tracked in memory (rather than re-read from storage) so the
+// <!> `no-bg-filter` toggle below always uses the value actually on
+// <!> screen right now. Storage writes for blur/bright are debounced by
+// <!> 600ms (see `propertiesUpdateDebounce`), so reading "the other"
+// <!> value back from storage.sync could return a stale figure if both
+// <!> sliders are moved within that window.
+let currentBlur: number | undefined
+let currentBright: number | undefined
 
 function applyFilters({ blur, bright, fadein }: Partial<Backgrounds>): void {
     if (blur !== undefined) {
+        currentBlur = blur
         document.documentElement.style.setProperty('--blur', `${blur}px`)
         document.body.classList.toggle('blurred', blur >= 15)
     }
 
     if (bright !== undefined) {
+        currentBright = bright
         document.documentElement.style.setProperty('--brightness', `${bright}`)
+    }
+
+    // <!> `filter: blur(0px) brightness(1)` still forces a GPU filter pass
+    // <!> on a full-viewport element every frame, even though it's a no-op
+    // <!> visually. When both values are at their defaults, drop `filter`
+    // <!> entirely via the `no-bg-filter` body class instead.
+    if (currentBlur !== undefined && currentBright !== undefined) {
+        document.body.classList.toggle('no-bg-filter', currentBlur === 0 && currentBright === 1)
     }
 
     if (fadein !== undefined) {
@@ -828,6 +1048,18 @@ function handleBackgroundOptions(backgrounds: Backgrounds): void {
     document.getElementById('background-freq-option')?.classList.toggle('shown', type !== 'color')
     document.getElementById('background-filters-options')?.classList.toggle('shown', type !== 'color')
     document.getElementById('background-video-sound-options')?.classList.toggle('shown', withVideos)
+
+    // <!> The Effect buttons live inside the Texture overlay section now
+    // <!> (settings.html's `.as_texture` -- an "as"/Show all settings
+    // <!> block), not a type-gated section of their own, so there's no
+    // <!> `.shown` toggle to do here. Only the selected-button state needs
+    // <!> syncing, and it needs to happen unconditionally (this runs from a
+    // <!> different init path than settings.ts's own `setEffectButtons` --
+    // <!> opening the settings panel fresh -- so it needs its own copy
+    // <!> rather than importing across modules).
+    for (const button of document.querySelectorAll<HTMLButtonElement>('.effect-button')) {
+        button.classList.toggle('selected', button.dataset.effect === backgrounds.effect)
+    }
 
     handleTextureOptions(backgrounds)
     handleProviderOptions(backgrounds)
@@ -1084,6 +1316,9 @@ export function toggleMuteStatus(muted = true): void {
 
 function isBackgroundType(str = ''): str is Sync['backgrounds']['type'] {
     return ['files', 'urls', 'images', 'videos', 'color'].includes(str)
+}
+function isBackgroundEffect(str = ''): str is Sync['backgrounds']['effect'] {
+    return ['none', 'firefly', 'rain'].includes(str)
 }
 function isBackgroundTexture(str = ''): str is Sync['backgrounds']['texture']['type'] {
     return [

--- a/src/scripts/features/backgrounds/local.ts
+++ b/src/scripts/features/backgrounds/local.ts
@@ -30,6 +30,14 @@ type LocalFileOption =
 let thumbnailVisibilityObserver: IntersectionObserver
 let thumbnailSelectionObserver: MutationObserver
 let currentVideoLooper: VideoLooper
+let uploadErrorTimeout: ReturnType<typeof setTimeout>
+
+// A single absurdly large file (a multi-GB video export, an uncompressed
+// TIFF, etc) won't just be slow to compress -- decoding it can exhaust tab
+// memory and hang or crash the page outright, with the upload UI frozen the
+// whole time and no way out. Better to reject it up front with a clear
+// reason than let the browser find out the hard way.
+const MAX_UPLOAD_SIZE_BYTES = 300 * 1024 * 1024 // 300 MB
 
 // Update
 
@@ -37,16 +45,37 @@ export async function addLocalBackgrounds(filelist: FileList | File[], local: Lo
     try {
         const thumbnailsContainer = document.getElementById('thumbnails-container')
         const filesData: Record<string, LocalFileData> = {}
-        const newids: string[] = []
-        let thumbnail: HTMLElement | undefined
+        const invalidFiles: string[] = []
+        const failedFiles: string[] = []
+        const oversizedFiles: string[] = []
+
+        // <!> `entries` pairs each accepted file with its id up front.
+        // <!> Previously `newids` (deduplicated) and `filelist` (not
+        // <!> deduplicated) were walked with the same index in step 2, so
+        // <!> a duplicate anywhere in the batch shifted every id after it
+        // <!> and silently saved files under the wrong id.
+        const entries: { file: File; id: string }[] = []
 
         if (filelist.length === 0) {
             return
         }
 
-        // 1. Add empty thumbnails
+        // 1. Validate file types & add empty thumbnails
 
         for (const file of filelist) {
+            const isImage = file.type.startsWith('image/')
+            const isVideo = file.type.startsWith('video/')
+
+            if (!isImage && !isVideo) {
+                invalidFiles.push(file.name || 'unnamed file')
+                continue
+            }
+
+            if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+                oversizedFiles.push(file.name || 'unnamed file')
+                continue
+            }
+
             const infosString = file.size.toString() + file.name + file.lastModified.toString()
             const hashString = hashcode(infosString).toString()
 
@@ -54,111 +83,153 @@ export async function addLocalBackgrounds(filelist: FileList | File[], local: Lo
                 continue
             }
 
-            newids.push(hashString)
+            entries.push({ file, id: hashString })
 
-            thumbnail = createThumbnail(hashString)
+            const thumbnail = createThumbnail(hashString)
             thumbnailsContainer?.appendChild(thumbnail)
             thumbnailSelectionObserver?.observe(thumbnail, { attributes: true })
         }
 
         if (thumbnailsContainer) {
-            const idsAmount = Object.keys(local.backgroundFiles).length + newids.length
+            const idsAmount = Object.keys(local.backgroundFiles).length + entries.length
             const columnsAmount = Math.min(idsAmount, 5).toString()
             thumbnailsContainer.style.setProperty('--thumbnails-columns', columnsAmount)
         }
 
         // 2. Compress files for background & thumbnail use
+        //
+        // <!> Each file is isolated in its own try/catch: one corrupt,
+        // <!> oversized, or otherwise unprocessable file no longer kills
+        // <!> the entire upload batch and leaves every other thumbnail
+        // <!> stuck in the loading state forever.
 
-        for (let i = 0; i < newids.length; i++) {
-            const file = filelist[i]
-            const id = newids[i]
-            const format = file.type.includes('video') ? 'video' : 'image'
+        showUploadProgress(entries.length)
 
-            // 2a. This finds a reasonable resolution for compression
+        let processedCount = 0
 
-            const isLandscape = globalThis.screen.orientation.type === 'landscape-primary'
-            const long = isLandscape ? globalThis.screen.width : globalThis.screen.height
-            const short = isLandscape ? globalThis.screen.height : globalThis.screen.width
-            const density = Math.min(2, globalThis.devicePixelRatio)
-            const ratio = Math.min(1.8, long / short)
-            const averagePixelHeight = short * ratio * density
+        for (const { file, id } of entries) {
+            try {
+                const format = file.type.includes('video') ? 'video' : 'image'
 
-            const isGif = file.type.includes('image/gif')
-            const isImage = file.type.includes('image/')
-            const isVideo = file.type.includes('video/')
-            const isThumbnailSize = file.size < 80000 // 80 kb
-            const isResonablySized = file.size < 300000 // 300 kb
+                // 2a. This finds a reasonable resolution for compression
 
-            let full: Blob = file
-            let small: Blob = file
+                const isLandscape = globalThis.screen.orientation.type === 'landscape-primary'
+                const long = isLandscape ? globalThis.screen.width : globalThis.screen.height
+                const short = isLandscape ? globalThis.screen.height : globalThis.screen.width
+                const density = Math.min(2, globalThis.devicePixelRatio)
+                const ratio = Math.min(1.8, long / short)
+                const averagePixelHeight = short * ratio * density
 
-            if (isImage) {
-                if (!isThumbnailSize) {
-                    const objectUrl = URL.createObjectURL(file)
-                    const dimensions = await imageDimensions(objectUrl)
-                    const width = dimensions.width
-                    const height = dimensions.height
-                    const isHighRes = averagePixelHeight * 2 < width + height
-                    const isCompressible = !isGif && !isResonablySized && isHighRes
+                const isGif = file.type.includes('image/gif')
+                const isImage = file.type.includes('image/')
+                const isVideo = file.type.includes('video/')
+                const isThumbnailSize = file.size < 80000 // 80 kb
+                const isResonablySized = file.size < 300000 // 300 kb
 
-                    if (isCompressible) {
-                        full = await compressAsBlob(objectUrl, { size: averagePixelHeight, q: 0.8 })
+                let full: Blob = file
+                let small: Blob = file
+
+                if (isImage) {
+                    if (!isThumbnailSize) {
+                        const objectUrl = URL.createObjectURL(file)
+
+                        try {
+                            const dimensions = await imageDimensions(objectUrl)
+                            const width = dimensions.width
+                            const height = dimensions.height
+                            const isHighRes = averagePixelHeight * 2 < width + height
+                            const isCompressible = !isGif && !isResonablySized && isHighRes
+
+                            if (isCompressible) {
+                                full = await compressAsBlob(objectUrl, { size: averagePixelHeight, q: 0.8 })
+                            }
+
+                            small = await compressAsBlob(objectUrl, { size: 360, q: 0.4 })
+                        } finally {
+                            URL.revokeObjectURL(objectUrl)
+                        }
                     }
-
-                    small = await compressAsBlob(objectUrl, { size: 360, q: 0.4 })
                 }
-            }
 
-            if (isVideo) {
-                const thumb = await generateImageFromVideo(file)
-                if (thumb) small = await compressAsBlob(thumb, { size: 360, q: 0.3 })
-            }
-
-            local.backgroundFiles[id] = {
-                format: 'image',
-                lastUsed: new Date().toString(),
-            }
-
-            if (format === 'video') {
-                local.backgroundFiles[id].format = 'video'
-                local.backgroundFiles[id].video = {
-                    playbackRate: 1,
-                    fade: 1,
-                    zoom: 1,
+                if (isVideo) {
+                    const thumb = await generateImageFromVideo(file)
+                    if (thumb) small = await compressAsBlob(thumb, { size: 360, q: 0.3 })
                 }
-            } else {
-                local.backgroundFiles[id].format = 'image'
-                local.backgroundFiles[id].position = {
-                    size: 'cover',
-                    x: '50%',
-                    y: '50%',
+
+                local.backgroundFiles[id] = {
+                    format: 'image',
+                    lastUsed: new Date().toString(),
                 }
+
+                if (format === 'video') {
+                    local.backgroundFiles[id].format = 'video'
+                    local.backgroundFiles[id].video = {
+                        playbackRate: 1,
+                        fade: 1,
+                        zoom: 1,
+                    }
+                } else {
+                    local.backgroundFiles[id].format = 'image'
+                    local.backgroundFiles[id].position = {
+                        size: 'cover',
+                        x: '50%',
+                        y: '50%',
+                    }
+                }
+
+                filesData[id] = {
+                    full,
+                    small,
+                }
+
+                await saveFileToCache(id, filesData[id])
+                addThumbnailImage(id, local, filesData[id])
+
+                storage.local.set({ backgroundFiles: local.backgroundFiles })
+            } catch (err) {
+                console.error(`Bonjourr: failed to add background "${file.name}"`, err)
+                failedFiles.push(file.name || 'unnamed file')
+
+                delete local.backgroundFiles[id]
+                delete filesData[id]
+
+                document.getElementById(id)?.remove()
+            } finally {
+                processedCount += 1
+                updateUploadProgress(processedCount, entries.length)
             }
-
-            filesData[id] = {
-                full,
-                small,
-            }
-
-            await saveFileToCache(id, filesData[id])
-            addThumbnailImage(id, local, filesData[id])
-
-            storage.local.set({ backgroundFiles: local.backgroundFiles })
         }
 
-        // 3. Apply background
+        hideUploadProgress()
 
-        if (newids.length > 0) {
-            const id = newids[0]
-            const media = await mediaFromFiles(id, local, filesData[id])
+        // 3. Apply background (first file that actually made it through)
+
+        const appliedId = entries.find(({ id }) => filesData[id])?.id
+
+        if (appliedId) {
+            const media = await mediaFromFiles(appliedId, local, filesData[appliedId])
 
             applyBackground(media)
             unselectAll()
 
-            thumbnail?.classList.add('selected')
+            document.getElementById(appliedId)?.classList.add('selected')
         }
 
-        // 4. Allow same file to be uploaded
+        // 4. Surface anything that went wrong instead of failing silently
+
+        const maxSizeMb = Math.round(MAX_UPLOAD_SIZE_BYTES / (1024 * 1024))
+
+        if (invalidFiles.length > 0 || failedFiles.length > 0 || oversizedFiles.length > 0) {
+            const messages = [
+                ...invalidFiles.map((name) => `"${name}" is not a supported image or video`),
+                ...oversizedFiles.map((name) => `"${name}" is larger than the ${maxSizeMb}MB upload limit`),
+                ...failedFiles.map((name) => `"${name}" could not be processed`),
+            ]
+
+            showUploadErrors(messages)
+        }
+
+        // 5. Allow same file to be uploaded
 
         const uploadInput = document.querySelector<HTMLInputElement>('#i_background-upload')
 
@@ -166,9 +237,58 @@ export async function addLocalBackgrounds(filelist: FileList | File[], local: Lo
             uploadInput.value = ''
         }
     } catch (e) {
-        console.info(e)
+        console.error('Bonjourr: uploading backgrounds failed', e)
+        showUploadErrors(['Something went wrong while uploading your file(s). Please try again.'])
+    } finally {
+        hideUploadProgress()
+    }
+}
+
+function showUploadProgress(total: number): void {
+    const container = document.getElementById('local-upload-progress')
+    const bar = document.getElementById('local-upload-progress-bar')
+    const text = document.getElementById('local-upload-progress-text')
+
+    if (total === 0 || !container) {
         return
     }
+
+    bar?.style.setProperty('--upload-progress-percent', '0%')
+    if (text) {
+        text.textContent = total === 1 ? 'Processing file…' : `Processing 0 of ${total} files…`
+    }
+
+    container.classList.add('shown')
+}
+
+function updateUploadProgress(done: number, total: number): void {
+    const bar = document.getElementById('local-upload-progress-bar')
+    const text = document.getElementById('local-upload-progress-text')
+    const percent = total > 0 ? Math.round((done / total) * 100) : 0
+
+    bar?.style.setProperty('--upload-progress-percent', `${percent}%`)
+    if (text) {
+        text.textContent = total === 1 ? 'Processing file…' : `Processing ${done} of ${total} files…`
+    }
+}
+
+function hideUploadProgress(): void {
+    document.getElementById('local-upload-progress')?.classList.remove('shown')
+}
+
+function showUploadErrors(messages: string[]): void {
+    const banner = document.getElementById('local-upload-error')
+
+    if (!banner) {
+        console.warn('Bonjourr upload errors:', messages)
+        return
+    }
+
+    banner.textContent = messages.join(' · ')
+    banner.classList.add('shown')
+
+    clearTimeout(uploadErrorTimeout)
+    uploadErrorTimeout = setTimeout(() => banner.classList.remove('shown'), 6000)
 }
 
 async function removeLocalBackgrounds(): Promise<void> {
@@ -592,7 +712,15 @@ async function handleThumbnailClick(this: HTMLButtonElement, mouseEvent: MouseEv
     if (isLeftClick) {
         const local = await storage.local.get()
         const metadata = local.backgroundFiles[id]
-        const image = await mediaFromFiles(id, local)
+
+        let image: Background | undefined
+
+        try {
+            image = await mediaFromFiles(id, local)
+        } catch (err) {
+            // Cache entry may have been evicted since the thumbnail was rendered
+            console.error(`Bonjourr: could not load background "${id}" from cache`, err)
+        }
 
         if (!metadata || !image) {
             console.warn('metadata: ', metadata)
@@ -691,6 +819,18 @@ function getSelection(): string[] {
 // Video
 
 export function setCurrentVideo(src: string, fade: number, playback: number): VideoLooper {
+    // <!> VideoLooper's constructor binds a `document`-level 'visibilitychange'
+    // <!> listener that's only ever unbound by calling `.remove()` or
+    // <!> `.unbindVisibilityListener()`. Without this, replacing the active
+    // <!> video background (every video-background swap, and again on every
+    // <!> "frequency" rotation) just orphaned the old VideoLooper -- its
+    // <!> listener, both <video> elements, and their blob-backed src stayed
+    // <!> reachable from `document` forever, compounding with every swap.
+    // <!> Only the listener is unbound here (not the full `.remove()`,
+    // <!> which would also force the old container's opacity to 0
+    // <!> immediately) because `applyBackground()`'s crossfade in index.ts
+    // <!> already owns fading out and detaching the outgoing container.
+    currentVideoLooper?.unbindVisibilityListener()
     currentVideoLooper = new VideoLooper(src, fade, playback)
     return currentVideoLooper
 }
@@ -699,16 +839,45 @@ export function getCurrentVideo(): VideoLooper | undefined {
     return currentVideoLooper
 }
 
+const VIDEO_LOAD_TIMEOUT_MS = 15000
+
 async function getLoadedVideo(blob: Blob): Promise<HTMLVideoElement> {
     const video = document.createElement('video')
-
     const url = URL.createObjectURL(blob)
-    video.src = url
 
-    await new Promise((r) => {
-        video.addEventListener('loadeddata', () => r(true))
-        video.load()
-    })
+    video.src = url
+    video.muted = true
+
+    try {
+        await new Promise<void>((resolve, reject) => {
+            // <!> Without a timeout and an `error` listener, a corrupt file
+            // <!> or an unsupported codec means `loadeddata` never fires and
+            // <!> this promise (and the whole upload) hangs forever.
+            const timeoutId = setTimeout(() => {
+                reject(new Error('Video took too long to load (it may be corrupt or use an unsupported codec)'))
+            }, VIDEO_LOAD_TIMEOUT_MS)
+
+            video.addEventListener('loadeddata', () => {
+                clearTimeout(timeoutId)
+                resolve()
+            }, { once: true })
+
+            video.addEventListener('error', () => {
+                clearTimeout(timeoutId)
+                reject(
+                    new Error(
+                        video.error?.message || 'Video failed to load (it may be corrupt or use an unsupported codec)',
+                    ),
+                )
+            }, { once: true })
+
+            video.load()
+        })
+    } catch (err) {
+        URL.revokeObjectURL(url)
+        video.remove()
+        throw err
+    }
 
     URL.revokeObjectURL(url)
 
@@ -721,6 +890,7 @@ async function generateImageFromVideo(file: File): Promise<Blob | null> {
     const ctx = canvas.getContext('2d')
 
     if (!ctx) {
+        video.remove()
         throw new Error('Canvas context failed for ' + file.name)
     }
 
@@ -729,18 +899,26 @@ async function generateImageFromVideo(file: File): Promise<Blob | null> {
 
     document.body.append(video)
     video.style.display = 'none'
-    video.play()
-    video.pause()
 
-    const blob = await new Promise<Blob>((resolve, reject) => {
-        const toBlobCallback: BlobCallback = (blob) => blob ? resolve(blob) : reject(true)
+    // <!> Waiting on a `seeked` event guarantees the browser has actually
+    // <!> decoded the frame at that timestamp before we draw it. The old
+    // <!> arbitrary 300ms timeout produced black thumbnails whenever decode
+    // <!> took longer than that (slow devices, big videos).
+    await new Promise<void>((resolve) => {
+        const seekTarget = Math.min(0.1, (video.duration || 0.2) / 2) || 0.1
+        const fallbackTimeout = setTimeout(resolve, 2000) // safety net, never hang
 
-        // <!> 300ms is completely arbitrary,
-        // <!> videos taking more than that to load will show a black thumbnail
-        setTimeout(() => {
-            ctx.drawImage(video, 0, 0, video.videoWidth, video.videoHeight)
-            ctx.canvas.toBlob(toBlobCallback, 'image/jpeg', 0.8)
-        }, 300)
+        video.addEventListener('seeked', () => {
+            clearTimeout(fallbackTimeout)
+            resolve()
+        }, { once: true })
+
+        video.currentTime = seekTarget
+    })
+
+    const blob = await new Promise<Blob | null>((resolve) => {
+        ctx.drawImage(video, 0, 0, video.videoWidth, video.videoHeight)
+        ctx.canvas.toBlob((blob) => resolve(blob), 'image/jpeg', 0.8)
     })
 
     video.remove()
@@ -764,18 +942,57 @@ export async function localFilesCacheControl(backgrounds: Backgrounds, local: Lo
 
     needNew ??= needsChange(freq, lastUsed)
 
+    let pickedId: string | undefined
+    let markLastUsed = false
+
     if (ids.length > 1 && needNew) {
-        ids.shift()
-
-        const rand = Math.floor(Math.random() * ids.length)
-        const id = ids[rand]
-
-        applyBackground(await mediaFromFiles(id, local))
-        local.backgroundFiles[id].lastUsed = new Date().toString()
-        storage.local.set(local)
+        const candidates = ids.slice(1)
+        const rand = Math.floor(Math.random() * candidates.length)
+        pickedId = candidates[rand]
+        markLastUsed = true
     } else {
-        applyBackground(await mediaFromFiles(ids[0], local))
+        pickedId = ids[0]
     }
+
+    // <!> `mediaFromFiles` reads from CacheStorage, which the browser is
+    // <!> free to evict at any time (storage pressure, private browsing,
+    // <!> the user clearing site data, etc). Previously a thrown error here
+    // <!> propagated straight out of `localFilesCacheControl` and the
+    // <!> background just silently failed to apply with zero feedback.
+    // <!> Now we drop the stale id and fall back through the rest of the
+    // <!> known files before giving up.
+    const remainingOrder = [pickedId, ...ids.filter((id) => id !== pickedId)]
+    let staleEntryFound = false
+
+    for (const id of remainingOrder) {
+        try {
+            const media = await mediaFromFiles(id, local)
+            applyBackground(media)
+
+            if (markLastUsed && id === pickedId) {
+                local.backgroundFiles[id].lastUsed = new Date().toString()
+            }
+
+            if (staleEntryFound) {
+                storage.local.set({ backgroundFiles: local.backgroundFiles })
+            } else if (markLastUsed) {
+                storage.local.set(local)
+            }
+
+            return
+        } catch (err) {
+            console.error(
+                `Bonjourr: background file "${id}" could not be loaded from cache, it may have been evicted. Skipping it.`,
+                err,
+            )
+            delete local.backgroundFiles[id]
+            staleEntryFound = true
+        }
+    }
+
+    // Every known file failed to load: the cache is likely gone entirely
+    storage.local.set({ backgroundFiles: local.backgroundFiles })
+    removeBackgrounds()
 }
 
 //  Storage
@@ -802,8 +1019,15 @@ async function saveFileToCache(id: string, filedata: LocalFileData): Promise<voi
 export async function getFileFromCache(id: string): Promise<LocalFileData> {
     const cache = await getCache('local-files')
 
-    const full = await (await cache?.match(`http://127.0.0.1:8888/${id}/full`))?.blob()
-    const small = await (await cache?.match(`http://127.0.0.1:8888/${id}/small`))?.blob()
+    // <!> These two reads are independent -- there's no reason to pay for
+    // <!> two sequential match()+blob() round trips (this is on the hot
+    // <!> path of every single background application, including the very
+    // <!> first paint on a new tab) when CacheStorage handles them fine in
+    // <!> parallel.
+    const [full, small] = await Promise.all([
+        cache?.match(`http://127.0.0.1:8888/${id}/full`).then((res) => res?.blob()),
+        cache?.match(`http://127.0.0.1:8888/${id}/small`).then((res) => res?.blob()),
+    ])
 
     if (!full || !small) {
         throw new Error(`${id} is undefined`)

--- a/src/scripts/features/contextmenu.ts
+++ b/src/scripts/features/contextmenu.ts
@@ -366,19 +366,21 @@ export function handleBackgroundActions(backgrounds: Backgrounds): void {
 
 export function initBackgroundActionsEvents(): void {
     onclickdown(document.getElementById('b_interface-background-pause'), () => {
-        toggleBackgroundPause()
+        toggleBackgroundPause().catch((err) => console.error('Bonjourr: failed to toggle background pause', err))
     })
 
     onclickdown(document.getElementById('b_interface-background-refresh'), (event) => {
-        backgroundUpdate({ refresh: event })
+        backgroundUpdate({ refresh: event }).catch((err) =>
+            console.error('Bonjourr: failed to refresh background', err)
+        )
     })
 
     onclickdown(document.getElementById('b_interface-background-download'), () => {
-        downloadImage()
+        downloadImage().catch((err) => console.error('Bonjourr: failed to download background', err))
     })
 
     onclickdown(document.getElementById('b_interface-background-mute'), () => {
-        toggleMuteVideo()
+        toggleMuteVideo().catch((err) => console.error('Bonjourr: failed to toggle video mute', err))
     })
 }
 
@@ -395,7 +397,7 @@ async function toggleMuteVideo(): Promise<void> {
     muteContextButton?.classList.toggle('muted', !lastMuteStatus)
 
     toggleMuteStatus(!lastMuteStatus)
-    backgroundUpdate({ mute: !lastMuteStatus })
+    await backgroundUpdate({ mute: !lastMuteStatus })
 }
 
 async function toggleBackgroundPause(): Promise<void> {
@@ -410,10 +412,10 @@ async function toggleBackgroundPause(): Promise<void> {
     }
 
     if (paused) {
-        backgroundUpdate({ freq: last })
+        await backgroundUpdate({ freq: last })
     } else {
         localStorage.lastBackgroundFreq = sync.backgrounds.frequency
-        backgroundUpdate({ freq: 'pause' })
+        await backgroundUpdate({ freq: 'pause' })
     }
 }
 

--- a/src/scripts/features/notes.ts
+++ b/src/scripts/features/notes.ts
@@ -20,7 +20,7 @@ const container = document.getElementById('notes_container')
 
 export function notes(init?: Notes, event?: NotesEvent): void {
     if (event) {
-        updateNotes(event)
+        updateNotes(event).catch((err) => console.error('Bonjourr: failed to update notes', err))
         return
     }
 
@@ -73,7 +73,7 @@ function initNotes(init: Notes): void {
     init.text = init.text ?? translateNotesText()
 
     new PocketEditor('#notes_container', { text: init.text, id: 'pocket-editor' }).oninput((content) => {
-        updateNotes({ text: content })
+        updateNotes({ text: content }).catch((err) => console.error('Bonjourr: failed to update notes', err))
     })
 }
 

--- a/src/scripts/features/quotes.ts
+++ b/src/scripts/features/quotes.ts
@@ -32,7 +32,17 @@ const quotesUrlForm = networkForm('f_qturl')
 
 export async function quotes(init?: QuotesInit, update?: QuotesUpdate): Promise<void> {
     if (update) {
-        updateQuotes(update)
+        // <!> Every caller of `quotes(undefined, update)` (settings.ts,
+        // <!> contextmenu.ts) fires this without awaiting or catching it.
+        // <!> `updateQuotes` does network fetches internally (via
+        // <!> `updateQuotesData` -> `fetchQuotes`), so without this the
+        // <!> whole chain could reject as an unhandled promise rejection on
+        // <!> any transient network failure.
+        try {
+            await updateQuotes(update)
+        } catch (err) {
+            console.error('Bonjourr: failed to update quotes', err)
+        }
         return
     }
 
@@ -111,7 +121,7 @@ async function updateQuotes({ author, frequency, type, userlist, url, refresh }:
     }
 
     if (updateData) {
-        updateQuotesData(data)
+        await updateQuotesData(data)
     }
 
     storage.sync.set({ quotes: data.quotes })

--- a/src/scripts/features/scribble.ts
+++ b/src/scripts/features/scribble.ts
@@ -1,0 +1,615 @@
+import { debounce, eventDebounce } from '../utils/debounce.ts'
+import { onSettingsLoad } from '../utils/onsettingsload.ts'
+import { tradThis } from '../utils/translations.ts'
+import { storage } from '../storage.ts'
+import PocketEditor from 'pocket-editor'
+
+import type { Scribble } from '../../types/sync.ts'
+
+// <!> This is a brand-new, standalone widget -- it does NOT touch `Notes`,
+// <!> `sync.notes`, `#notes_container`, or any of `notes.ts`. Separate
+// <!> storage keys, separate DOM, separate module. It's a small draggable,
+// <!> resizable "mini window" that remembers its screen position and size,
+// <!> and holds BOTH typed markdown (reusing `pocket-editor`, same as
+// <!> Notes) and a freehand doodle, stacked in the same space -- not two
+// <!> separate modes/views. The pencil button just decides which layer
+// <!> currently receives pointer input; both are always rendered, so ink
+// <!> can overlap text, which is the point ("if the doodles overlap the
+// <!> text, that's fine -- up to the user, it's a fun lil thing"). Position,
+// <!> size, and drawing strokes are device-local (`Local.scribblePosition`/
+// <!> `Local.scribbleSize`/`Local.scribbleDrawing`) since they're either
+// <!> per-device or too bulky for `storage.sync`'s small quota; on/off +
+// <!> draw-mode + markdown text stay in `storage.sync` since they're small
+// <!> and worth syncing across devices, same tier as `sync.notes`.
+
+type ScribbleEvent = {
+    toggle?: boolean
+    draw?: boolean
+    text?: string
+    clear?: true
+}
+
+type Point = [number, number]
+type Size = { width: number; height: number }
+
+const MIN_WIDTH = 200
+const MIN_HEIGHT = 160
+const MAX_WIDTH = 640
+const MAX_HEIGHT = 640
+const DEFAULT_SIZE: Size = { width: 260, height: 268 }
+
+const container = document.getElementById('scribble_container')
+const handle = document.getElementById('scribble_handle')
+const stage = document.getElementById('scribble_stage')
+const writeContainer = document.getElementById('scribble_write')
+const canvas = document.getElementById('scribble_draw') as HTMLCanvasElement | null
+const ctx = canvas?.getContext('2d') ?? undefined
+
+let initialized = false
+let strokes: Point[][] = []
+let currentStroke: Point[] | undefined
+let isDragging = false
+let dragOffset: Point = [0, 0]
+let isResizing = false
+let editorInstance: PocketEditor | undefined
+
+// <!> The single in-memory source of truth for `storage.sync.scribble`,
+// <!> set once in `initScribble`. Every `updateScribble` call mutates THIS
+// <!> object and debounce-saves it, rather than each call independently
+// <!> re-reading storage, mutating, and writing back -- two events fired
+// <!> close together (e.g. typing, then immediately pressing the pencil)
+// <!> could otherwise each read the *same* pre-write snapshot, and whichever
+// <!> one's debounced write lands last would silently clobber the other's
+// <!> change (e.g. the draw-mode toggle winning and reverting the just-typed
+// <!> text). Same reasoning as `strokes` already being in-memory state for
+// <!> the drawing, just applied to the sync side too.
+let scribbleState: Scribble | undefined
+
+export function scribble(init?: Scribble, event?: ScribbleEvent): void {
+    if (event) {
+        updateScribble(event)
+        return
+    }
+
+    if (init) {
+        init.on ? initScribble(init) : onSettingsLoad(() => initScribble(init))
+    }
+}
+
+// <!> Synchronous, not async -- mutates the in-memory `scribbleState` and
+// <!> schedules a debounced `storage.sync.set` (see `eventDebounce`), no
+// <!> `await` needed anywhere in between.
+function updateScribble(event: ScribbleEvent): void {
+    const scribble = scribbleState
+
+    if (!scribble) {
+        return
+    }
+
+    if (event.toggle !== undefined) {
+        scribble.on = event.toggle
+        handleToggle(scribble.on)
+    }
+
+    if (event.draw !== undefined) {
+        scribble.draw = event.draw
+        handleDraw(scribble.draw)
+    }
+
+    if (event.text !== undefined) {
+        scribble.text = event.text
+    }
+
+    if (event.clear) {
+        strokes = []
+        clearCanvas()
+        storage.local.set({ scribbleDrawing: '' })
+    }
+
+    eventDebounce({ scribble })
+}
+
+//
+//	Funcs
+//
+
+function initScribble(init: Scribble): void {
+    handleToggle(init.on)
+    handleDraw(init.draw ?? false)
+    syncSettingsCheckbox(init.on)
+
+    if (initialized) {
+        return
+    }
+
+    initialized = true
+    scribbleState = { ...init }
+
+    if (writeContainer) {
+        editorInstance = new PocketEditor('#scribble_write', {
+            text: init.text ?? translateScribbleText(),
+            id: 'scribble-pocket-editor',
+        })
+        editorInstance.oninput((content) => {
+            updateScribble({ text: content })
+        })
+        bindEmptySpaceFocus()
+    }
+
+    initPosition().catch((err) => console.error('Bonjourr: failed to restore scribble position', err))
+    initSize().catch((err) => console.error('Bonjourr: failed to restore scribble size', err))
+    initDrawing().catch((err) => console.error('Bonjourr: failed to restore scribble drawing', err))
+
+    bindHandleDrag()
+    bindResizeHandles()
+    bindCanvasDrawing()
+    bindControls()
+    observeStageSize()
+}
+
+// <!> The mounted editor fills the *whole* pad (`min-height: 100%` on
+// <!> `#scribble-pocket-editor`, see scribble.css), but its actual editable
+// <!> line(s) are only as tall as their content -- on a short/empty pad,
+// <!> that's a thin strip at the very top. Without this, clicking anywhere
+// <!> in the (very plausible, it's a big blank writing surface) empty space
+// <!> below that strip lands on nothing focusable, and every keystroke that
+// <!> follows silently goes nowhere. Clicking empty space now focuses the
+// <!> last line and drops the caret at its end, same as clicking below the
+// <!> last line of text in a real text editor.
+function bindEmptySpaceFocus(): void {
+    writeContainer?.addEventListener('pointerdown', (event) => {
+        const target = event.target as HTMLElement | null
+
+        if (target?.closest('[contenteditable="true"]')) {
+            return
+        }
+
+        event.preventDefault()
+        focusEditorEnd()
+    })
+}
+
+function focusEditorEnd(): void {
+    const lines = editorInstance?.lines
+    const lastLine = lines?.[lines.length - 1]
+
+    // <!> `editor.lines` holds each line's *wrapper* element (e.g. the
+    // <!> `<div>` around a `<p contenteditable>`), not necessarily something
+    // <!> focusable itself -- the actual editable node one level down is
+    // <!> what needs `.focus()`.
+    const editable = lastLine?.querySelector<HTMLElement>('[contenteditable="true"]') ?? lastLine
+
+    if (!editable) {
+        return
+    }
+
+    editable.focus()
+
+    const selection = globalThis.getSelection()
+    const range = document.createRange()
+    range.selectNodeContents(editable)
+    range.collapse(false)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+}
+
+function handleToggle(state: boolean): void {
+    container?.classList.toggle('hidden', !state)
+}
+
+function handleDraw(active: boolean): void {
+    container?.classList.toggle('draw-mode', active)
+    document.getElementById('scribble_pencil')?.classList.toggle('selected', active)
+
+    // Entering doodle mode routes pointer input to the canvas (see CSS:
+    // `.draw-mode #scribble_write { pointer-events: none }`) -- drop any
+    // active text cursor/selection so it doesn't sit there uselessly
+    // blinking underneath the ink.
+    if (active) {
+        const editor = document.getElementById('scribble-pocket-editor')
+        if (editor?.contains(document.activeElement)) {
+            ;(document.activeElement as HTMLElement | null)?.blur()
+        }
+    }
+}
+
+function syncSettingsCheckbox(state: boolean): void {
+    const checkbox = document.getElementById('i_scribble') as HTMLInputElement | null
+
+    if (checkbox) {
+        checkbox.checked = state
+    }
+}
+
+function translateScribbleText(): string {
+    const line1 = tradThis('Scribble pad')
+    const line2 = tradThis('A tiny playful window for quick markdown notes -- press the pencil to doodle on top')
+
+    return `## ${line1}\n\n${line2}`
+}
+
+//	Position (drag to move, remembers where you left it)
+
+async function initPosition(): Promise<void> {
+    const { scribblePosition } = await storage.local.get('scribblePosition')
+    applyPosition(scribblePosition ?? { x: 40, y: 120 })
+}
+
+function applyPosition(pos: { x: number; y: number }): void {
+    if (!container) {
+        return
+    }
+
+    const maxX = Math.max(0, globalThis.innerWidth - container.offsetWidth - 8)
+    const maxY = Math.max(0, globalThis.innerHeight - container.offsetHeight - 8)
+    const x = Math.min(Math.max(8, pos.x), maxX)
+    const y = Math.min(Math.max(8, pos.y), maxY)
+
+    container.style.left = `${x}px`
+    container.style.top = `${y}px`
+}
+
+const savePosition = debounce((pos: { x: number; y: number }) => {
+    storage.local.set({ scribblePosition: pos })
+}, 300)
+
+function bindHandleDrag(): void {
+    if (!handle || !container) {
+        return
+    }
+
+    handle.addEventListener('pointerdown', (event) => {
+        const pointerEvent = event as PointerEvent
+
+        if ((pointerEvent.target as HTMLElement)?.closest('button')) {
+            return
+        }
+
+        const rect = container.getBoundingClientRect()
+        dragOffset = [pointerEvent.clientX - rect.left, pointerEvent.clientY - rect.top]
+        isDragging = true
+
+        handle.setPointerCapture(pointerEvent.pointerId)
+        container.classList.add('dragging')
+    })
+
+    handle.addEventListener('pointermove', (event) => {
+        if (!isDragging) {
+            return
+        }
+
+        const pointerEvent = event as PointerEvent
+        const pos = {
+            x: pointerEvent.clientX - dragOffset[0],
+            y: pointerEvent.clientY - dragOffset[1],
+        }
+
+        applyPosition(pos)
+        savePosition(pos)
+    })
+
+    const stopDrag = () => {
+        isDragging = false
+        container.classList.remove('dragging')
+    }
+
+    handle.addEventListener('pointerup', stopDrag)
+    handle.addEventListener('pointercancel', stopDrag)
+
+    globalThis.addEventListener('resize', () => {
+        if (container.classList.contains('hidden')) {
+            return
+        }
+
+        const left = Number.parseFloat(container.style.left || '0')
+        const top = Number.parseFloat(container.style.top || '0')
+        applyPosition({ x: left, y: top })
+    })
+}
+
+//	Size (drag any edge/corner to resize, remembers its dimensions)
+
+async function initSize(): Promise<void> {
+    const { scribbleSize } = await storage.local.get('scribbleSize')
+    applySize(scribbleSize ?? DEFAULT_SIZE)
+}
+
+function applySize(size: Size): void {
+    if (!container) {
+        return
+    }
+
+    const maxWidth = Math.min(MAX_WIDTH, globalThis.innerWidth - 16)
+    const maxHeight = Math.min(MAX_HEIGHT, globalThis.innerHeight - 16)
+    const width = Math.min(Math.max(MIN_WIDTH, size.width), Math.max(MIN_WIDTH, maxWidth))
+    const height = Math.min(Math.max(MIN_HEIGHT, size.height), Math.max(MIN_HEIGHT, maxHeight))
+
+    container.style.width = `${width}px`
+    container.style.height = `${height}px`
+}
+
+const saveSize = debounce((size: Size) => {
+    storage.local.set({ scribbleSize: size })
+}, 300)
+
+const RESIZE_DIRS = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'] as const
+
+function bindResizeHandles(): void {
+    if (!container) {
+        return
+    }
+
+    for (const dir of RESIZE_DIRS) {
+        const handleEl = container.querySelector<HTMLElement>(`.scribble_resize[data-dir="${dir}"]`)
+
+        handleEl?.addEventListener('pointerdown', (event) => {
+            const pointerEvent = event as PointerEvent
+            const rect = container.getBoundingClientRect()
+
+            const start = {
+                x: pointerEvent.clientX,
+                y: pointerEvent.clientY,
+                width: rect.width,
+                height: rect.height,
+                left: rect.left,
+                top: rect.top,
+            }
+
+            isResizing = true
+            container.classList.add('resizing')
+            handleEl.setPointerCapture(pointerEvent.pointerId)
+
+            const onMove = (moveEvent: PointerEvent) => {
+                if (!isResizing) {
+                    return
+                }
+
+                const dx = moveEvent.clientX - start.x
+                const dy = moveEvent.clientY - start.y
+
+                let width = start.width
+                let height = start.height
+                let left = start.left
+                let top = start.top
+
+                if (dir.includes('e')) {
+                    width = start.width + dx
+                }
+                if (dir.includes('w')) {
+                    width = start.width - dx
+                    left = start.left + dx
+                }
+                if (dir.includes('s')) {
+                    height = start.height + dy
+                }
+                if (dir.includes('n')) {
+                    height = start.height - dy
+                    top = start.top + dy
+                }
+
+                applySize({ width, height })
+
+                // Resizing from the top/left edges keeps the *opposite*
+                // corner visually anchored -- the container grows/shrinks
+                // toward the pointer instead of just toward the bottom-right,
+                // which is what makes north/west handles feel like a real
+                // resize instead of a move.
+                if (dir.includes('w') || dir.includes('n')) {
+                    applyPosition({ x: left, y: top })
+                }
+            }
+
+            const onEnd = () => {
+                isResizing = false
+                container.classList.remove('resizing')
+                handleEl.removeEventListener('pointermove', onMove)
+                handleEl.removeEventListener('pointerup', onEnd)
+                handleEl.removeEventListener('pointercancel', onEnd)
+
+                const finalRect = container.getBoundingClientRect()
+                const size = { width: finalRect.width, height: finalRect.height }
+                saveSize(size)
+
+                if (dir.includes('w') || dir.includes('n')) {
+                    const left = Number.parseFloat(container.style.left || '0')
+                    const top = Number.parseFloat(container.style.top || '0')
+                    savePosition({ x: left, y: top })
+                }
+            }
+
+            handleEl.addEventListener('pointermove', onMove)
+            handleEl.addEventListener('pointerup', onEnd)
+            handleEl.addEventListener('pointercancel', onEnd)
+        })
+    }
+}
+
+//	Drawing (freehand doodle mode)
+
+// <!> Canvas backing-store size tracks the *actual* rendered size of
+// <!> `#scribble_stage`, not a fixed constant -- the stage now flexes to
+// <!> fill however big/small the user has resized the container to. A
+// <!> `ResizeObserver` (not the resize-handle drag code) is the single
+// <!> source of truth for this, so canvas sizing stays correct regardless
+// <!> of *why* the stage's size changed (a resize-handle drag, the
+// <!> viewport itself resizing and reflowing layout, etc).
+function sizeCanvas(): void {
+    if (!canvas || !stage) {
+        return
+    }
+
+    const dpr = globalThis.devicePixelRatio || 1
+    const width = stage.clientWidth
+    const height = stage.clientHeight
+
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+    // Resizing a canvas element (setting .width/.height, even to the same
+    // value) wipes its bitmap -- always redraw whatever strokes we have
+    // right after, or a resize looks like it silently erased the doodle.
+    ctx?.setTransform(dpr, 0, 0, dpr, 0, 0)
+    redrawStrokes()
+}
+
+async function initDrawing(): Promise<void> {
+    const { scribbleDrawing } = await storage.local.get('scribbleDrawing')
+
+    try {
+        strokes = scribbleDrawing ? JSON.parse(scribbleDrawing) : []
+    } catch (_) {
+        strokes = []
+    }
+
+    sizeCanvas()
+}
+
+// <!> Debounced, not called on every resize-handle pointermove frame --
+// <!> tearing down/rebuilding the canvas backing store (and redrawing every
+// <!> stroke) on each of those would be wasteful. The stage's CSS size
+// <!> (driven by flex, following the container) already updates instantly
+// <!> during a drag; only the canvas's actual pixel backing store lags
+// <!> slightly behind, which is imperceptible at this debounce window.
+const resizeCanvasDebounced = debounce(sizeCanvas, 80)
+
+function observeStageSize(): void {
+    if (!stage || typeof ResizeObserver === 'undefined') {
+        return
+    }
+
+    new ResizeObserver(() => resizeCanvasDebounced()).observe(stage)
+}
+
+function bindCanvasDrawing(): void {
+    if (!canvas) {
+        return
+    }
+
+    canvas.addEventListener('pointerdown', (event) => {
+        if (event.pointerType === 'mouse' && event.button !== 0) {
+            return
+        }
+
+        currentStroke = [[event.offsetX, event.offsetY]]
+        strokes.push(currentStroke)
+        canvas.setPointerCapture(event.pointerId)
+        drawDot(event.offsetX, event.offsetY)
+    })
+
+    canvas.addEventListener('pointermove', (event) => {
+        if (!currentStroke) {
+            return
+        }
+
+        currentStroke.push([event.offsetX, event.offsetY])
+        drawSegment(currentStroke)
+    })
+
+    const endStroke = () => {
+        if (!currentStroke) {
+            return
+        }
+
+        currentStroke = undefined
+        persistDrawing()
+    }
+
+    canvas.addEventListener('pointerup', endStroke)
+    canvas.addEventListener('pointerleave', endStroke)
+    canvas.addEventListener('pointercancel', endStroke)
+}
+
+function drawDot(x: number, y: number): void {
+    if (!ctx) {
+        return
+    }
+
+    ctx.fillStyle = strokeColor()
+    ctx.beginPath()
+    ctx.arc(x, y, 1.25, 0, Math.PI * 2)
+    ctx.fill()
+}
+
+function drawSegment(stroke: Point[]): void {
+    if (!ctx || stroke.length < 2) {
+        return
+    }
+
+    const [x1, y1] = stroke[stroke.length - 2]
+    const [x2, y2] = stroke[stroke.length - 1]
+
+    ctx.strokeStyle = strokeColor()
+    ctx.lineWidth = 2.5
+    ctx.lineCap = 'round'
+    ctx.lineJoin = 'round'
+    ctx.beginPath()
+    ctx.moveTo(x1, y1)
+    ctx.lineTo(x2, y2)
+    ctx.stroke()
+}
+
+// <!> Canvas 2D context colors can't be CSS `var()` references -- unlike a
+// <!> stylesheet, `ctx.fillStyle = 'rgb(var(--x))'` is silently rejected
+// <!> (the assignment is ignored, leaving strokes drawn in the context's
+// <!> previous/default color -- black, invisible against this widget's
+// <!> dark blurred background). Resolve the custom property to real RGB
+// <!> channel numbers once and reuse them.
+let cachedStrokeColor: string | undefined
+
+function strokeColor(): string {
+    if (!cachedStrokeColor) {
+        const channels = getComputedStyle(document.documentElement).getPropertyValue('--font-on-blur-color').trim()
+        cachedStrokeColor = `rgb(${channels || '255 255 255'})`
+    }
+
+    return cachedStrokeColor
+}
+
+function redrawStrokes(): void {
+    if (!ctx) {
+        return
+    }
+
+    clearCanvas()
+
+    for (const stroke of strokes) {
+        if (stroke.length === 1) {
+            drawDot(stroke[0][0], stroke[0][1])
+            continue
+        }
+
+        for (let i = 1; i < stroke.length; i++) {
+            drawSegment(stroke.slice(0, i + 1))
+        }
+    }
+}
+
+function clearCanvas(): void {
+    if (!ctx || !canvas) {
+        return
+    }
+
+    const dpr = globalThis.devicePixelRatio || 1
+    ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr)
+}
+
+const persistDrawing = debounce(() => {
+    storage.local.set({ scribbleDrawing: JSON.stringify(strokes) })
+}, 400)
+
+//	Controls (mode switch, clear, close)
+
+function bindControls(): void {
+    document.getElementById('scribble_pencil')?.addEventListener('click', () => {
+        const active = container?.classList.contains('draw-mode') ?? false
+        updateScribble({ draw: !active })
+    })
+
+    document.getElementById('scribble_clear')?.addEventListener('click', () => {
+        updateScribble({ clear: true })
+    })
+
+    document.getElementById('scribble_close')?.addEventListener('click', () => {
+        syncSettingsCheckbox(false)
+        updateScribble({ toggle: false })
+    })
+}

--- a/src/scripts/features/searchbar.ts
+++ b/src/scripts/features/searchbar.ts
@@ -58,7 +58,7 @@ const setBackground = (value = '#fff2') => {
 
 export function searchbar(init?: Searchbar, update?: SearchbarUpdate): void {
     if (update) {
-        updateSearchbar(update)
+        updateSearchbar(update).catch((err) => console.error('Bonjourr: failed to update searchbar', err))
         return
     }
 

--- a/src/scripts/features/weather/display.ts
+++ b/src/scripts/features/weather/display.ts
@@ -147,6 +147,37 @@ export function displayWeather(data: Weather, lastWeather: LastWeather): void {
     }
 }
 
+/**
+ * Shown when there's no cached weather to fall back to and the first
+ * request fails (offline, provider down, geolocation denied with no
+ * default city reachable, etc). Without this, `#weather` keeps its
+ * initial `.wait` class (opacity: 0) forever -- an invisible gap in the
+ * layout with no indication anything went wrong. This makes the failure
+ * visible and un-stuck instead.
+ */
+export function displayWeatherUnavailable(): void {
+    const weatherdom = document.getElementById('weather')
+    const currentDesc = document.getElementById('current-desc')
+    const tempContainer = document.getElementById('tempContainer')
+    const dotContainer = document.getElementById('dotContainer')
+    const forecastdom = document.getElementById('forecast')
+
+    if (currentDesc) {
+        currentDesc.innerText = tradThis('Weather unavailable')
+    }
+
+    tempContainer?.replaceChildren()
+    dotContainer?.replaceChildren()
+    forecastdom?.classList.remove('shown')
+    weatherdom?.removeAttribute('href')
+
+    if (weatherFirstStart) {
+        weatherFirstStart = false
+        weatherdom?.classList.remove('wait')
+        setTimeout(() => weatherdom?.classList.remove('init'), 900)
+    }
+}
+
 // potential flaw: forecast timing is based on computer date instead of userDate()
 export function handleForecastDisplay(forecast: string): void {
     // // forces forecast for debugging

--- a/src/scripts/features/weather/index.ts
+++ b/src/scripts/features/weather/index.ts
@@ -47,7 +47,9 @@ export function weather(init?: WeatherInit, update?: WeatherUpdate): void {
     const canShowWeather = !(weatherHidden || mainHidden)
 
     if (canShowWeather) {
-        weatherCacheControl(init.sync.weather, init.lastWeather)
+        weatherCacheControl(init.sync.weather, init.lastWeather).catch((err) => {
+            console.error('Bonjourr: weather init failed', err)
+        })
     }
 
     onSettingsLoad(() => {
@@ -58,9 +60,13 @@ export function weather(init?: WeatherInit, update?: WeatherUpdate): void {
         clearInterval(pollingInterval)
 
         pollingInterval = setInterval(async () => {
-            const sync = await storage.sync.get(['weather', 'hide', 'main'])
-            const local = await storage.local.get('lastWeather')
-            weatherCacheControl(sync.weather, local.lastWeather)
+            try {
+                const sync = await storage.sync.get(['weather', 'hide', 'main'])
+                const local = await storage.local.get('lastWeather')
+                await weatherCacheControl(sync.weather, local.lastWeather)
+            } catch (err) {
+                console.error('Bonjourr: weather polling failed', err)
+            }
         }, 1200000) // 20min
     })
 }

--- a/src/scripts/features/weather/request.ts
+++ b/src/scripts/features/weather/request.ts
@@ -1,4 +1,4 @@
-import { displayWeather, handleForecastDisplay } from './display.ts'
+import { displayWeather, displayWeatherUnavailable, handleForecastDisplay } from './display.ts'
 import { getLang, tradThis } from '../../utils/translations.ts'
 import { handleGeolOption } from './settings.ts'
 import { getSunsetHour } from './index.ts'
@@ -14,7 +14,7 @@ export async function weatherCacheControl(data: Weather, lastWeather?: LastWeath
     handleForecastDisplay(data.forecast)
 
     if (!lastWeather) {
-        firstStartWeather(data)
+        await firstStartWeather(data)
         return
     }
 
@@ -23,17 +23,29 @@ export async function weatherCacheControl(data: Weather, lastWeather?: LastWeath
     const isAnHourLater = now > last + 3600000
 
     if (navigator.onLine && isAnHourLater) {
-        const newWeather = await requestNewWeather(data, lastWeather)
+        try {
+            const newWeather = await requestNewWeather(data, lastWeather)
 
-        if (newWeather) {
-            storage.local.set({ lastWeather: newWeather })
-            displayWeather(data, newWeather)
-            return
+            if (newWeather) {
+                storage.local.set({ lastWeather: newWeather })
+                displayWeather(data, newWeather)
+                return
+            }
+        } catch (err) {
+            // <!> A transient failure here (offline, provider down, bad
+            // <!> response) used to throw all the way out of this function
+            // <!> uncaught, which also skipped the `displayWeather(data,
+            // <!> lastWeather)` fallback below -- the widget just silently
+            // <!> stopped updating. Falling back to the last known-good
+            // <!> weather is strictly better than showing nothing.
+            console.warn('Bonjourr: failed to refresh weather, showing cached data', err)
         }
     }
 
     displayWeather(data, lastWeather)
 }
+
+const WEATHER_FETCH_TIMEOUT_MS = 10000
 
 export async function requestNewWeather(data: Weather, lastWeather?: LastWeather): Promise<LastWeather | undefined> {
     if (!navigator.onLine) {
@@ -59,7 +71,23 @@ export async function requestNewWeather(data: Weather, lastWeather?: LastWeather
         url.searchParams.set('query', q)
     }
 
-    const response = await fetch(url)
+    // <!> Plain `fetch()` has no timeout: on a hung connection (captive
+    // <!> portal, a dead VPN route, a firewall that drops packets instead
+    // <!> of rejecting them) this would await forever. That's worse than a
+    // <!> clean network error -- it never reaches the catch block in
+    // <!> `firstStartWeather`/`weatherCacheControl` at all, so the "show
+    // <!> cached data" and "show unavailable" fallbacks never fire either.
+    // <!> Confirmed live: in this sandbox, a request with no lat/lon/query
+    // <!> hangs indefinitely rather than erroring.
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), WEATHER_FETCH_TIMEOUT_MS)
+
+    let response: Response
+    try {
+        response = await fetch(url, { signal: controller.signal })
+    } finally {
+        clearTimeout(timeoutId)
+    }
 
     if (response.status !== 200) {
         throw new Error('Cannot get weather')
@@ -122,17 +150,30 @@ export async function requestNewWeather(data: Weather, lastWeather?: LastWeather
 }
 
 async function firstStartWeather(data: Weather): Promise<void> {
-    const currentWeather = await requestNewWeather(data)
+    try {
+        const currentWeather = await requestNewWeather(data)
 
-    if (currentWeather) {
-        data.city = currentWeather.approximation?.city ?? tradThis('City')
+        if (currentWeather) {
+            data.city = currentWeather.approximation?.city ?? tradThis('City')
 
-        storage.sync.set({ weather: data })
-        storage.local.set({ lastWeather: currentWeather })
+            storage.sync.set({ weather: data })
+            storage.local.set({ lastWeather: currentWeather })
 
-        displayWeather(data, currentWeather)
-        setTimeout(() => handleGeolOption(data), 400)
+            displayWeather(data, currentWeather)
+            setTimeout(() => handleGeolOption(data), 400)
+            return
+        }
+    } catch (err) {
+        // request.ts's `throw new Error('Cannot get weather')` on a bad
+        // response (and any network failure) lands here.
+        console.warn('Bonjourr: initial weather request failed', err)
     }
+
+    // <!> With no cached weather yet (first run) and a failed/offline
+    // <!> request, there is nothing to fall back to. Previously this left
+    // <!> #weather stuck at `opacity: 0` (the `.wait` class) forever --
+    // <!> an invisible gap with zero indication anything went wrong.
+    displayWeatherUnavailable()
 }
 
 export async function getGeolocation(type: Weather['geolocation']): Promise<Coords | undefined> {

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -13,6 +13,7 @@ import { weather } from './features/weather/index.ts'
 import { quotes } from './features/quotes.ts'
 import { pomodoro } from './features/pomodoro.ts'
 import { notes } from './features/notes.ts'
+import { scribble } from './features/scribble.ts'
 import { clock } from './features/clock/index.ts'
 import './features/contextmenu.ts'
 
@@ -31,8 +32,19 @@ import { storage } from './storage.ts'
 
 import { BROWSER, CURRENT_VERSION, LOCAL_DEFAULT, PLATFORM, SYNC_DEFAULT, SYSTEM_OS } from './defaults.ts'
 
+// <!> `startup()` is async: a synchronous try/catch around a fire-and-forget
+// <!> call to it only catches an error thrown before its first `await`
+// <!> (practically never, since `await storage.init()` is its first line).
+// <!> Everything after that -- which is nearly the entire startup
+// <!> sequence -- was rejecting as a fully unhandled promise rejection
+// <!> instead of hitting this catch, leaving the page silently
+// <!> half-initialized on any failure. `.catch()` is what actually
+// <!> observes an async function's rejection.
+startup().catch((err) => {
+    console.error('Bonjourr: startup failed', err)
+})
+
 try {
-    startup()
     serviceWorker()
     onlineAndMobile()
 } catch (_) {
@@ -83,6 +95,7 @@ async function startup(): Promise<void> {
     quotes({ sync, local })
     pomodoro(sync.pomodoro)
     notes(sync.notes)
+    scribble(sync.scribble)
     moveElements(sync.move)
     customCss(sync.css)
     hideElements(sync.hide)
@@ -109,7 +122,18 @@ async function startup(): Promise<void> {
         document.body.classList.remove('init')
 
         supportersNotifications(sync)
-        setPotatoComputerMode()
+
+        // <!> Defense in depth: `setPotatoComputerMode` reads WebGL debug
+        // <!> info that can be unavailable/blocklisted in ways we can't
+        // <!> fully predict across browsers. A throw here must never skip
+        // <!> `userActions`/`interfacePopup` below, which wire up core
+        // <!> interface listeners.
+        try {
+            setPotatoComputerMode()
+        } catch (err) {
+            console.error('Bonjourr: potato mode detection failed', err)
+        }
+
         userActions(sync.advanced)
 
         interfacePopup({

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -14,6 +14,7 @@ import { searchbar } from './features/searchbar.ts'
 import { weather } from './features/weather/index.ts'
 import { quotes } from './features/quotes.ts'
 import { notes } from './features/notes.ts'
+import { scribble } from './features/scribble.ts'
 import { clock } from './features/clock/index.ts'
 import { pomodoro, setModeGlider } from './features/pomodoro.ts'
 import { togglePomodoroFocus } from './features/pomodoro.ts'
@@ -181,6 +182,7 @@ function initOptionsValues(data: Sync, local: Local): void {
     setInput('i_icon_radius', data.linkiconradius || 1.1)
     setInput('i_linkstyle', data.linkstyle || 'default')
     setInput('i_type', data.backgrounds.type || 'images')
+    setEffectButtons(data.backgrounds?.effect || 'none')
     setInput('i_freq', data.backgrounds?.frequency || 'hour')
     setInput('i_dark', data.dark || 'system')
     setInput('i_favicon', data.favicon ?? '')
@@ -258,6 +260,7 @@ function initOptionsValues(data: Sync, local: Local): void {
     setCheckbox('i_show_unit', data.weather.show_unit ?? false)
     setCheckbox('i_greethide', !data.hide?.greetings)
     setCheckbox('i_notes', data.notes?.on ?? false)
+    setCheckbox('i_scribble', data.scribble?.on ?? false)
     setCheckbox('i_sb', data.searchbar?.on ?? false)
     setCheckbox('i_quotes', data.quotes?.on ?? false)
     setCheckbox('i_pomodoro', data.pomodoro?.on ?? false)
@@ -430,7 +433,7 @@ function initOptionsEvents(): void {
     })
 
     paramId('i_lang').addEventListener('change', function (): void {
-        switchLangs(this.value as Langs)
+        switchLangs(this.value as Langs).catch((err) => console.error('Bonjourr: failed to switch language', err))
     })
 
     paramId('i_favicon').addEventListener('input', function (this: HTMLInputElement): void {
@@ -522,6 +525,14 @@ function initOptionsEvents(): void {
     paramId('i_type').addEventListener('change', function (this: HTMLInputElement): void {
         backgroundUpdate({ type: this.value })
     })
+
+    for (const button of document.querySelectorAll<HTMLButtonElement>('.effect-button')) {
+        button.addEventListener('click', function (this: HTMLButtonElement): void {
+            const effect = this.dataset.effect ?? 'firefly'
+            setEffectButtons(effect)
+            backgroundUpdate({ effect })
+        })
+    }
 
     paramId('b_solid-background').addEventListener('click', function (): void {
         paramId('i_solid-background').click()
@@ -807,6 +818,12 @@ function initOptionsEvents(): void {
         notes(undefined, { background: true })
     })
 
+    // Scribble pad
+
+    onclickdown(paramId('i_scribble'), (_, target) => {
+        scribble(undefined, { toggle: target.checked })
+    })
+
     onclickdown(paramId('i_notes-shade'), () => {
         notes(undefined, { background: true })
     })
@@ -1049,7 +1066,7 @@ function initOptionsEvents(): void {
     })
 
     paramId('b_file-save').addEventListener('click', () => {
-        saveImportFile()
+        saveImportFile().catch((err) => console.error('Bonjourr: failed to save settings file', err))
     })
 
     paramId('file-import').addEventListener('change', function (this): void {
@@ -1061,24 +1078,34 @@ function initOptionsEvents(): void {
     })
 
     paramId('settings-data').addEventListener('input', (event) => {
-        toggleSettingsChangesButtons(event.type)
+        toggleSettingsChangesButtons(event.type).catch((err) =>
+            console.error('Bonjourr: settings panel update failed', err)
+        )
     })
 
     paramId('settings-data').addEventListener('focus', (event) => {
-        toggleSettingsChangesButtons(event.type)
+        toggleSettingsChangesButtons(event.type).catch((err) =>
+            console.error('Bonjourr: settings panel update failed', err)
+        )
     })
 
     paramId('settings-data').addEventListener('blur', (event) => {
-        toggleSettingsChangesButtons(event.type)
+        toggleSettingsChangesButtons(event.type).catch((err) =>
+            console.error('Bonjourr: settings panel update failed', err)
+        )
     })
 
     onclickdown(paramId('b_settings-cancel'), () => {
-        toggleSettingsChangesButtons('cancel')
+        toggleSettingsChangesButtons('cancel').catch((err) =>
+            console.error('Bonjourr: settings panel update failed', err)
+        )
     })
 
     onclickdown(paramId('b_settings-apply'), () => {
         const val = paramId('settings-data').value
-        importSettings(parse<Partial<Sync>>(val) ?? {})
+        importSettings(parse<Partial<Sync>>(val) ?? {}).catch((err) =>
+            console.error('Bonjourr: failed to apply settings', err)
+        )
     })
 
     // applies settings-data when cmd/ctrl + enter
@@ -1537,8 +1564,8 @@ async function importSettings(imported: Partial<Sync>): Promise<void> {
         }
 
         fadeOut()
-    } catch (_) {
-        // ...
+    } catch (err) {
+        console.error('Bonjourr: failed to import settings', err)
     }
 }
 
@@ -1658,6 +1685,16 @@ function setCheckbox(id: string, cat: boolean): void {
 function setInput(id: string, val: string | number): void {
     const input = paramId(id) as HTMLInputElement
     input.value = typeof val === 'string' ? val : val?.toString()
+}
+
+// Background "Effects" picker is a small button group (see #effect-buttons
+// in settings.html), not a <select> -- "selected" is a class toggle across
+// all of them, keyed by the `data-effect` each button carries, rather than
+// a single element's `.value`.
+function setEffectButtons(effect: string): void {
+    for (const button of document.querySelectorAll<HTMLButtonElement>('.effect-button')) {
+        button.classList.toggle('selected', button.dataset.effect === effect)
+    }
 }
 
 function setFormInput(id: string, defaults: string, value?: string): void {

--- a/src/scripts/shared/compress.ts
+++ b/src/scripts/shared/compress.ts
@@ -6,54 +6,115 @@ interface CompressOptions {
     square?: boolean
 }
 
+type Crop = { sx: number; sy: number; sWidth: number; sHeight: number; dWidth: number; dHeight: number }
+
+function computeCrop(width: number, height: number, options: CompressOptions): Crop {
+    const { size, square } = options
+    const isLandscape = width > height
+
+    let sx = 0
+    let sy = 0
+    let sWidth = width
+    let sHeight = height
+    let dWidth = size ?? width
+    let dHeight = size ?? height
+
+    if (!size) {
+        return { sx, sy, sWidth, sHeight, dWidth: width, dHeight: height }
+    }
+
+    if (!square) {
+        if (isLandscape) {
+            dHeight = size
+            dWidth = (width / height) * size
+        } else {
+            dWidth = size
+            dHeight = (height / width) * size
+        }
+    } else {
+        if (isLandscape) {
+            sx = (width - height) / 2
+            sWidth = sHeight = height
+        } else {
+            sy = (height - width) / 2
+            sWidth = sHeight = width
+        }
+    }
+
+    return { sx, sy, sWidth, sHeight, dWidth: Math.round(dWidth), dHeight: Math.round(dHeight) }
+}
+
+/**
+ * `createImageBitmap()` decodes (and, with a source-rectangle + `resize*`
+ * options, crops and resizes in the same call) off the main thread in every
+ * browser that supports it. That matters a lot here: the synchronous
+ * `<img>` decode + full-resolution `ctx.drawImage()` this replaces can
+ * block the main thread for hundreds of milliseconds on a large photo, and
+ * with a big batch upload that adds up to a UI that looks fully hung.
+ *
+ * Returns `undefined` (never throws) if the API is unavailable or the
+ * decode fails for any reason, so `loadOnCanvas` can fall back to the
+ * always-works `<img>` path below.
+ */
+async function loadBitmapOffMainThread(url: string, options: CompressOptions): Promise<ImageBitmap | undefined> {
+    if (typeof createImageBitmap !== 'function') {
+        return undefined
+    }
+
+    let full: ImageBitmap | undefined
+
+    try {
+        const blob = await fetch(url).then((res) => res.blob())
+        full = await createImageBitmap(blob)
+
+        const { raw } = options
+        if (raw || !options.size) {
+            const result = full
+            full = undefined
+            return result
+        }
+
+        const { sx, sy, sWidth, sHeight, dWidth, dHeight } = computeCrop(full.width, full.height, options)
+        const resized = await createImageBitmap(full, sx, sy, sWidth, sHeight, {
+            resizeWidth: dWidth,
+            resizeHeight: dHeight,
+            resizeQuality: 'high',
+        })
+
+        return resized
+    } catch (err) {
+        console.warn('Bonjourr: off-main-thread image decode failed, falling back to <img>', err)
+        return undefined
+    } finally {
+        full?.close()
+    }
+}
+
 async function loadOnCanvas(url: string, options: CompressOptions): Promise<HTMLCanvasElement> {
     const canvas = document.createElement('canvas')
     const ctx = canvas.getContext('2d')
-    const img = new Image()
 
     if (!ctx) {
         throw new Error('Cannot get canvas context')
     }
 
+    const bitmap = await loadBitmapOffMainThread(url, options)
+
+    if (bitmap) {
+        canvas.width = bitmap.width
+        canvas.height = bitmap.height
+        ctx.drawImage(bitmap, 0, 0)
+        bitmap.close()
+        return canvas
+    }
+
+    // Fallback: synchronous <img> decode on the main thread. Only reached
+    // when createImageBitmap is unsupported or threw above.
+    const img = new Image()
+
     await new Promise((resolve) => {
         img.onload = () => {
-            const { size, square, raw } = options
-
-            if (raw || !size) {
-                canvas.width = img.width
-                canvas.height = img.height
-                ctx?.drawImage(img, 0, 0)
-
-                img.remove()
-                resolve(true)
-                return
-            }
-
-            const isLandscape = img.width > img.height
-            let sx = 0
-            let sy = 0
-            let sWidth = img.width
-            let sHeight = img.height
-            let dWidth = size
-            let dHeight = size
-
-            if (!square) {
-                if (isLandscape) {
-                    dHeight = size
-                    dWidth = (img.width / img.height) * size
-                } else {
-                    dWidth = size
-                    dHeight = (img.height / img.width) * size
-                }
-            } else {
-                if (isLandscape) {
-                    sx = (img.width - img.height) / 2
-                    sWidth = sHeight = img.height
-                } else {
-                    sy = (img.height - img.width) / 2
-                    sWidth = sHeight = img.width
-                }
-            }
+            const { sx, sy, sWidth, sHeight, dWidth, dHeight } = computeCrop(img.width, img.height, options)
 
             canvas.width = dWidth
             canvas.height = dHeight
@@ -99,11 +160,26 @@ export async function compressAsBlob(elem: Blob | string, options: CompressOptio
 
     const canvas = await loadOnCanvas(elem, options)
     const ctx = canvas.getContext('2d')
-    const newBlob = await new Promise((resolve) => {
-        ctx?.canvas.toBlob(resolve, `image/${type}`, q)
+
+    if (!ctx) {
+        throw new Error('Cannot get canvas context')
+    }
+
+    const newBlob = await new Promise<Blob | null>((resolve) => {
+        ctx.canvas.toBlob(resolve, `image/${type}`, q)
     })
 
-    return newBlob as Blob
+    // <!> canvas.toBlob() can call back with `null` (e.g. the canvas is
+    // <!> tainted, out of memory, or zero-sized). Previously this was cast
+    // <!> straight to `Blob`, and callers exploded downstream with no
+    // <!> useful error message.
+    if (!newBlob) {
+        throw new Error(
+            'Image compression failed: canvas.toBlob() returned no data (image may be corrupt, empty, or the browser ran out of memory)',
+        )
+    }
+
+    return newBlob
 }
 
 export async function compressAsDataUri(elem: Blob | string, options: CompressOptions): Promise<string> {

--- a/src/scripts/startup/potato.ts
+++ b/src/scripts/startup/potato.ts
@@ -25,8 +25,15 @@ export function setPotatoComputerMode(): void {
         return
     }
 
-    const vendor = gl?.getParameter(debugInfo?.UNMASKED_VENDOR_WEBGL ?? 0).toString()
-    const renderer = gl?.getParameter(debugInfo?.UNMASKED_RENDERER_WEBGL ?? 0).toString()
+    // <!> `.toString()` used to sit outside the optional chain, so on any
+    // <!> Chromium-based browser other than Chrome itself (Edge, Brave,
+    // <!> Opera, Vivaldi) that lacks WebGL, `gl` is undefined,
+    // <!> `gl?.getParameter(...)` short-circuits to `undefined`, and
+    // <!> `undefined.toString()` throws. Since this runs inside the
+    // <!> `onInterfaceDisplay` callback ahead of `userActions()` and
+    // <!> `interfacePopup()`, that throw used to silently skip both.
+    const vendor = gl?.getParameter(debugInfo?.UNMASKED_VENDOR_WEBGL ?? 0)?.toString() ?? ''
+    const renderer = gl?.getParameter(debugInfo?.UNMASKED_RENDERER_WEBGL ?? 0)?.toString() ?? ''
     const detectedPotato = vendor.includes('Google') && renderer.includes('SwiftShader')
 
     localStorage.potato = detectedPotato ? 'yes' : 'no'

--- a/src/scripts/storage.ts
+++ b/src/scripts/storage.ts
@@ -239,7 +239,15 @@ async function localGet(keys?: string | string[]): Promise<Local> {
         case 'webext-sync':
         case 'webext-local': {
             const data = await chrome.storage.local.get(keys) as unknown as Local
-            return data
+
+            // <!> Unlike `syncGet`, this used to return chrome.storage's raw
+            // <!> contents with no default-merging. On a fresh profile (or
+            // <!> any key that hasn't been explicitly saved yet), fields
+            // <!> like `backgroundFiles` come back `undefined` instead of
+            // <!> their default, which made background code throw ("Cannot
+            // <!> convert undefined or null to object") the very first time
+            // <!> a user tried to upload a wallpaper.
+            return verifyDataAsLocal(data)
         }
 
         default: {

--- a/src/scripts/utils/debounce.ts
+++ b/src/scripts/utils/debounce.ts
@@ -20,6 +20,29 @@ export function debounce<F extends AnyFunction>(callback: F, waitFor: number): D
     return debounced
 }
 
-export const eventDebounce = debounce((value: Record<string, unknown>) => {
-    storage.sync.set(value)
-}, 400)
+// <!> `eventDebounce` is called from ~15 unrelated call sites across the
+// <!> app (notes, searchbar, css, clock, fonts, links, tab title, page
+// <!> width/gap, text shadow, favicon...). It used to be a single shared
+// <!> `debounce()` instance with one timeout: any two calls within 400ms
+// <!> canceled each other and only the *last* call's value ever reached
+// <!> storage. E.g. dragging the page-width slider then typing a tab title
+// <!> within 400ms silently dropped the page-width write. Debouncing is
+// <!> now keyed per top-level settings key (every call site here passes a
+// <!> single-key object), so unrelated settings no longer race each other
+// <!> -- rapid writes to the *same* key still coalesce into one, same as
+// <!> before.
+const eventDebounceTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+export function eventDebounce(value: Record<string, unknown>): void {
+    for (const key of Object.keys(value)) {
+        clearTimeout(eventDebounceTimeouts.get(key))
+
+        eventDebounceTimeouts.set(
+            key,
+            setTimeout(() => {
+                eventDebounceTimeouts.delete(key)
+                storage.sync.set({ [key]: value[key] })
+            }, 400),
+        )
+    }
+}

--- a/src/settings.html
+++ b/src/settings.html
@@ -279,6 +279,13 @@
 
         <div class="wrapper" id="thumbnails-container"></div>
 
+        <div id="local-upload-progress" class="upload-progress" role="status" aria-live="polite">
+            <div id="local-upload-progress-bar"></div>
+            <span id="local-upload-progress-text"></span>
+        </div>
+
+        <div id="local-upload-error" class="upload-error" role="alert"></div>
+
         <div id="background-local-actions" class="wrapper">
             <div>
                 <button
@@ -564,6 +571,24 @@
                 <label for="i_texture-size" class="trn">Texture density</label>
                 <input id="i_texture-size" name="texture-size" class="range" type="range" />
             </div>
+        </div>
+
+        <hr />
+
+        <div class="wrapper">
+            <p class="trn">Effect</p>
+        </div>
+
+        <div id="effect-buttons" class="wrapper">
+            <button class="effect-button param-btn" data-effect="none" type="button">
+                <span class="trn">None</span>
+            </button>
+            <button class="effect-button param-btn" data-effect="firefly" type="button">
+                <span class="trn">Fireflies</span>
+            </button>
+            <button class="effect-button param-btn" data-effect="rain" type="button">
+                <span class="trn">Cozy rain</span>
+            </button>
         </div>
     </div>
 </div>
@@ -1375,6 +1400,24 @@
                 </div>
             </div>
         </div>
+    </div>
+</div>
+
+<div class="settings-title" id="scribble_title">
+    <h2 id="lbl-scribble" class="trn">Scribble pad</h2>
+
+    <button class="tooltip ttscribble" title="Tips on Scribble pad" aria-label="Tips Scribble pad">?</button>
+
+    <p class="tooltiptext dropdown ttscribble">
+        <span
+            class="trn">A tiny floating window you can drag anywhere on the page. Write markdown or doodle -- it remembers where you left it.</span>
+    </p>
+</div>
+
+<div class="param" id="scribble_param">
+    <div class="activate_scribble wrapper">
+        <label for="i_scribble" class="trn">Enable</label>
+        <input id="i_scribble" class="switch" type="checkbox" />
     </div>
 </div>
 

--- a/src/styles/components/dialog.css
+++ b/src/styles/components/dialog.css
@@ -8,6 +8,17 @@ dialog {
     box-shadow: 0px 0px 15px #0004;
 }
 
+/* Potato mode: this base rule alone covers every <dialog> in the app
+   (contextmenu, confirmations, etc. -- more specific selectors like
+   #bookmarks/#editlink in _global.css already opt out of blur too, and
+   win on specificity where they disagree with this). `--color-dialog`
+   already carries enough opacity on its own to stay legible without the
+   4em blur. */
+body.potato dialog {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+}
+
 dialog hr {
     margin: 10px;
     box-sizing: border-box;

--- a/src/styles/features/links.css
+++ b/src/styles/features/links.css
@@ -198,7 +198,8 @@
     /* will-change: transform; */
 }
 
-.link .link-icon, .link .link-index {
+.link .link-icon,
+.link .link-index {
     margin: auto;
     flex-shrink: 0;
     width: var(--icon-size);
@@ -252,7 +253,8 @@
     top: 3.5em;
 }
 
-.titles.small.layout-text-left, .titles.small.layout-text-right {
+.titles.small.layout-text-left,
+.titles.small.layout-text-right {
     text-align: center;
 }
 
@@ -824,4 +826,31 @@
 .with-groups #link-mini,
 .in-folder #link-mini {
     display: block;
+}
+
+/* Potato mode
+ *
+ * .link-folder .link-icon is the biggest win here: it's one backdrop-filter
+ * per folder tile, and pages can have many folders on screen at once.
+ * The rest (folder-open list, pinned/selected group titles, hover tooltip)
+ * are all text-bearing and use light low-alpha backgrounds designed to
+ * work together with blur, so text needs a dark fallback instead
+ * (matches search bar / notes / clock treatment elsewhere).
+ */
+
+body.potato .link-folder .link-icon,
+body.potato .link-folder:active .link-icon,
+body.potato .link-group.hiding .link-folder .link-icon {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(255 255 255 / 0.35);
+}
+
+body.potato .link-group.in-folder .link-list,
+body.potato .link-title.selected-group,
+body.potato .link-group.pinned .link-title,
+body.potato .link .link-elem-title {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(0 0 0 / 0.55);
 }

--- a/src/styles/features/notes.css
+++ b/src/styles/features/notes.css
@@ -43,6 +43,21 @@
     -webkit-backdrop-filter: blur(2em);
 }
 
+/* Potato mode: same reasoning as the search bar -- --notes-background is
+   only ~10% opaque and depends on the blur behind it for legibility. */
+body.potato #pocket-editor {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(0 0 0 / 0.55);
+}
+
+/* .opaque means the user picked a near-white custom notes color, which
+   also switches the text to dark (#222) above -- keep that combination
+   working by falling back to a light color here instead of the dark one. */
+body.potato #notes_container.opaque #pocket-editor {
+    background-color: rgb(255 255 255 / 0.85);
+}
+
 #pocket-editor [data-selected] {
     color: #fff;
     background-color: rgb(255 255 255 / 0.1333333333);

--- a/src/styles/features/pomodoro.css
+++ b/src/styles/features/pomodoro.css
@@ -147,6 +147,31 @@ body.pomodoro-focus:has(#pomodoro_container:not(.hidden)) #interface {
     box-shadow: inset -10px -8px 0px -11px rgb(255 255 255 / 0.4), inset 0px -9px 0px -8px rgb(255 255 255 / 0.4);
 }
 
+/* Potato mode: the pomodoro widget stacks several backdrop-filters and a
+   drop-shadow filter (.glass, .glass::after, .glider, #focus-toggle,
+   #focus-toggle::after) on top of each other -- each one is its own
+   expensive compositing pass. Drop them all and fall back to a single
+   flat, still-legible dark panel (text here is --font-on-blur-color,
+   always white). */
+body.potato .glass,
+body.potato .glider,
+body.potato #pmdr_modes .pomodoro_mode.active,
+body.potato #focus-toggle,
+body.potato #focus-toggle:hover {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: rgb(0 0 0 / 0.4);
+}
+
+body.potato .glass::after,
+body.potato #focus-toggle::after {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    filter: none;
+    background: transparent;
+    box-shadow: none;
+}
+
 #pmdr_modes .pomodoro_mode {
     background: transparent;
     border-radius: 10em;

--- a/src/styles/features/scribble.css
+++ b/src/styles/features/scribble.css
@@ -1,0 +1,273 @@
+/* <!> Standalone floating "mini window" widget, entirely separate from
+   the `Notes` widget (#notes_container / notes.css) -- own container, own
+   z-index, own positioning. It lives outside #interface so it can float
+   freely at an arbitrary screen position regardless of the grid layout. */
+
+#scribble_container {
+    position: fixed;
+    top: 120px;
+    left: 40px;
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    /* <!> Default size only -- once the user drags a resize handle,
+       `applySize()` (scribble.ts) pins concrete inline `width`/`height` px
+       values here and persists them to `Local.scribbleSize`, same pattern
+       as position. `#scribble_stage` below fills whatever's left via flex,
+       so it never needs its own fixed size. */
+    width: 260px;
+    height: 268px;
+    min-width: 200px;
+    min-height: 160px;
+    overflow: hidden;
+    border-radius: 1em;
+    box-shadow: rgb(0 0 0 / 0.24) 0px 3px 8px;
+    border: 1px solid rgb(255 255 255 / 0.075);
+    /* <!> Deliberately its own value, not a read of `--notes-background` --
+       that variable is only ever written by `notes.ts`, and reading it here
+       would silently couple this widget's look to Notes' own background
+       settings. Fully separate widget, fully separate styling. */
+    background-color: rgb(255 255 255 / 0.1);
+    backdrop-filter: blur(2em);
+    -webkit-backdrop-filter: blur(2em);
+    transition: box-shadow 0.2s, transform 0.1s;
+}
+
+#scribble_container.hidden {
+    display: none;
+}
+
+#scribble_container.dragging {
+    box-shadow: rgb(0 0 0 / 0.4) 0px 6px 16px;
+    transform: scale(1.01);
+}
+
+#scribble_container.resizing {
+    box-shadow: rgb(0 0 0 / 0.4) 0px 6px 16px;
+}
+
+/* <!> Eight invisible strips/corners along the inside edge of the
+   container -- "resize cursors at the edges", a real draggable-window
+   feel instead of the single browser-native bottom-right `resize: both`
+   handle. Kept fully inside the box (no negative offsets) so they aren't
+   clipped by the container's own `overflow: hidden` / rounded corners. */
+.scribble_resize {
+    position: absolute;
+    touch-action: none;
+}
+
+.scribble_resize[data-dir='n'] {
+    top: 0;
+    left: 10px;
+    right: 10px;
+    height: 6px;
+    cursor: ns-resize;
+}
+
+.scribble_resize[data-dir='s'] {
+    bottom: 0;
+    left: 10px;
+    right: 10px;
+    height: 6px;
+    cursor: ns-resize;
+}
+
+.scribble_resize[data-dir='e'] {
+    top: 10px;
+    bottom: 10px;
+    right: 0;
+    width: 6px;
+    cursor: ew-resize;
+}
+
+.scribble_resize[data-dir='w'] {
+    top: 10px;
+    bottom: 10px;
+    left: 0;
+    width: 6px;
+    cursor: ew-resize;
+}
+
+.scribble_resize[data-dir='ne'] {
+    top: 0;
+    right: 0;
+    width: 12px;
+    height: 12px;
+    cursor: nesw-resize;
+}
+
+.scribble_resize[data-dir='nw'] {
+    top: 0;
+    left: 0;
+    width: 12px;
+    height: 12px;
+    cursor: nwse-resize;
+}
+
+.scribble_resize[data-dir='se'] {
+    bottom: 0;
+    right: 0;
+    width: 12px;
+    height: 12px;
+    cursor: nwse-resize;
+}
+
+.scribble_resize[data-dir='sw'] {
+    bottom: 0;
+    left: 0;
+    width: 12px;
+    height: 12px;
+    cursor: nesw-resize;
+}
+
+body.potato #scribble_container {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(0 0 0 / 0.55);
+}
+
+#scribble_handle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5em;
+    padding: 0.5em 0.6em;
+    cursor: grab;
+    touch-action: none;
+    color: rgb(var(--font-on-blur-color));
+    border-bottom: 1px solid rgb(255 255 255 / 0.075);
+    user-select: none;
+}
+
+#scribble_container.dragging #scribble_handle {
+    cursor: grabbing;
+}
+
+#scribble_handle-actions {
+    display: flex;
+    gap: 0.25em;
+}
+
+#scribble_pencil,
+#scribble_clear,
+#scribble_close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.8em;
+    height: 1.8em;
+    padding: 0;
+    font-size: 0.85em;
+    line-height: 1;
+    color: rgb(var(--font-on-blur-color));
+    background: none;
+    border: none;
+    border-radius: 0.5em;
+    opacity: 0.6;
+    cursor: pointer;
+}
+
+#scribble_pencil:hover,
+#scribble_clear:hover,
+#scribble_close:hover {
+    opacity: 1;
+    background-color: rgb(255 255 255 / 0.1333333333);
+}
+
+/* <!> "Pressed" pencil = doodle mode is on. Unclicked (the normal,
+   default state) is plain markdown editing -- clean, rendered text, no
+   ink layer capturing input. Press it to doodle; press again to go back
+   to typing. Both layers stay visible and stacked the whole time (see
+   `#scribble_stage` below) -- this only ever changes who receives
+   pointer input, never what's shown. */
+#scribble_pencil.selected {
+    opacity: 1;
+    color: #0d0b14;
+    background-color: rgb(var(--font-on-blur-color));
+}
+
+/* <!> Text and doodle are one combined surface, not two separate
+   views -- both children always rendered, stacked via grid so ink can sit
+   on top of (and overlap) the markdown underneath. Only `pointer-events`
+   toggles by mode, deciding whether a click types or draws; nothing here
+   ever hides either layer. */
+#scribble_stage {
+    display: grid;
+    grid-template-areas: 'stage';
+    width: 100%;
+    /* Fills whatever's left of the container's (resizable) height once the
+       handle bar takes its own natural height -- see `#scribble_container`. */
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+#scribble_write,
+#scribble_draw {
+    grid-area: stage;
+    width: 100%;
+    height: 100%;
+}
+
+#scribble_write {
+    min-width: 0;
+    overflow-y: auto;
+    pointer-events: auto;
+    /* Scrollable without a visible scrollbar -- wheel/trackpad/touch drag
+       still scroll normally, the track+thumb just never paints. */
+    scrollbar-width: none;
+}
+
+#scribble_write::-webkit-scrollbar {
+    display: none;
+}
+
+#scribble_container.draw-mode #scribble_write {
+    pointer-events: none;
+}
+
+/* <!> `pocket-editor`'s own stylesheet styles its mounted editable element
+   by attribute (`[data-pocket-editor] { background-color: var(--pe-color-background) }`,
+   an opaque white, with dark text) -- an ID selector on the *wrapper*
+   (`#scribble_write`) doesn't beat that, since the editable node the
+   library actually paints is the child carrying `id="scribble-pocket-editor"`
+   (the `id` option passed to `new PocketEditor(...)`). Same reasoning as
+   notes.css targeting `#pocket-editor` rather than `#notes_container`. */
+#scribble-pocket-editor {
+    min-height: 100%;
+    padding: 1em;
+    color: rgb(var(--font-on-blur-color));
+    background-color: transparent;
+    font-size: 1em;
+    text-align: initial;
+    text-shadow: none;
+    line-height: 1.5em;
+}
+
+#scribble-pocket-editor:empty:after {
+    content: attr(placeholder);
+    opacity: 0.5;
+}
+
+#scribble-pocket-editor [data-selected] {
+    color: #fff;
+    background-color: rgb(255 255 255 / 0.1333333333);
+}
+
+#scribble-pocket-editor ul {
+    margin: 0;
+    padding-left: 1.4em;
+}
+
+#scribble-pocket-editor li {
+    list-style: inherit;
+}
+
+#scribble_draw {
+    pointer-events: none;
+    touch-action: none;
+}
+
+#scribble_container.draw-mode #scribble_draw {
+    pointer-events: auto;
+    cursor: crosshair;
+}

--- a/src/styles/features/searchbar.css
+++ b/src/styles/features/searchbar.css
@@ -50,6 +50,26 @@
     -webkit-backdrop-filter: blur(2em);
 }
 
+/* Potato mode: --searchbar-background is only ~10% opaque, tuned to work
+   together with the blur behind it. Without blur that reads as nearly
+   invisible over a busy wallpaper, so fall back to a much more opaque
+   dark tint instead -- text here is always white (--font-on-blur-color),
+   so this has to stay dark regardless of the light/dark theme. */
+body.potato #searchbar-wrapper,
+body.potato #sb-suggestions {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(0 0 0 / 0.55);
+}
+
+/* .opaque means the user picked a near-white custom searchbar color,
+   which also switches the text dark (#333) above -- keep that working
+   with a light fallback instead of the dark one. */
+body.potato #sb_container.opaque #searchbar-wrapper,
+body.potato #sb_container.opaque #sb-suggestions {
+    background-color: rgb(255 255 255 / 0.85);
+}
+
 #searchbar {
     width: 100%;
     height: 2.5em;

--- a/src/styles/features/time.css
+++ b/src/styles/features/time.css
@@ -155,6 +155,16 @@
     color: rgb(var(--font-on-blur-color));
 }
 
+/* Potato mode: same reasoning as search bar / notes -- the always-white
+   clock face text needs a dark-regardless-of-theme fallback. Skipped
+   entirely for #time.transparent, which already has its own
+   deliberately-transparent no-blur look (see rule below). */
+body.potato #time:not(.transparent) .analog {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(0 0 0 / 0.55);
+}
+
 /* shape */
 #time[data-shape='round'] .analog {
     border-radius: 100%;

--- a/src/styles/interface/background.css
+++ b/src/styles/interface/background.css
@@ -56,6 +56,47 @@
     display: none;
 }
 
+/* <!> The effect iframe is a transparent overlay layered on top of
+   whatever the real background is (photo, video, or solid color) -- it's
+   shown whenever `effect` isn't 'none', regardless of `data-type`. Its own
+   document (src/assets/effects/*.html) has a transparent body so the real
+   background shows through underneath it. */
+#background-effect {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    /* A background must never intercept clicks meant for the interface
+       above it -- same rule every other background type already follows. */
+    pointer-events: none;
+    /* <!> Deliberately no `filter: blur(var(--blur)) brightness(var(--brightness))`
+       here, unlike every other background type. That filter exists to dim/soften a
+       busy *photo* so foreground text stays legible -- applied to a small, fine-detail
+       animation (individual fireflies, thin rain streaks) it was blurring and dimming
+       the effect down to practically nothing at Bonjourr's own defaults (15px blur,
+       0.8 brightness). Each effect already ships with its own dark, legible-by-design
+       palette, so it doesn't need the photo-legibility treatment -- it needs to
+       actually be visible, which was the reported bug. */
+    will-change: opacity;
+}
+
+#background-wrapper:not([data-effect='none']) #background-effect {
+    display: block;
+}
+
+/* Effects are full-viewport canvas animations -- exactly the CPU/GPU cost
+   potato mode exists to avoid. `applyEffectBackground` (backgrounds/index.ts)
+   already skips mounting the iframe under `body.potato`; this is the visual
+   half of that. No flat-color fallback needed here (unlike an early version
+   of this feature) -- the real background underneath is untouched by potato
+   mode and still renders normally, the overlay just doesn't mount. */
+body.potato #background-effect {
+    display: none;
+}
+
 #background-media .video-looper,
 #background-media .background-image {
     object-fit: cover;
@@ -63,6 +104,17 @@
     background-position: center;
     transform: scale(1.1);
     filter: blur(var(--blur)) brightness(var(--brightness));
+    /* Promote the compositing layer upfront instead of letting the browser
+       create it on demand during the first paint, which is expensive. */
+    will-change: transform, opacity;
+}
+
+/* blur(0px) brightness(1) is still a real GPU filter pass on a
+   full-viewport element every frame even though it's a visual no-op --
+   skip `filter` entirely when both values are at their defaults. */
+body.no-bg-filter #background-media .video-looper,
+body.no-bg-filter #background-media .background-image {
+    filter: none;
 }
 
 #background-media [data-res='small'] {
@@ -79,6 +131,16 @@
     opacity: 0;
 }
 
+/* Potato mode (low-end / software-rendered GPU): drop the 1.1x scale
+   overdraw and shorten the crossfade so low-end devices aren't paying
+   for a slow, full-viewport opacity transition on every background change. */
+body.potato #background-media .video-looper,
+body.potato #background-media .background-image {
+    transform: none;
+    transition: opacity 300ms;
+    will-change: opacity;
+}
+
 [data-browser='safari'] #background-media .video-looper,
 [data-browser='safari'] #background-media .background-image {
     transform: scale(1.1) translateX(0px) translate3d(0, 0, 0);
@@ -86,6 +148,21 @@
 
 body.init #background-media .video-looper,
 body.init #background-media .background-image {
+    transition: none;
+}
+
+/* <!> The very first background reveal (new tab, before the interface has
+   even finished its own first paint -- `body.init` is only removed once
+   clock/links/fonts/etc all report ready, ~333ms minimum) has nothing to
+   protect from flicker: there is no previous wallpaper on screen to
+   crossfade from. Fading #background-wrapper in over `--fade-in` (400ms by
+   default) here is pure added latency between "image is decoded and ready"
+   and "pixels are actually visible" -- it's what reads as "gently drawing
+   in" after a beat of black. Skip the transition entirely for this one
+   reveal; every later background change (switching wallpapers, frequency
+   rotation) still gets the normal crossfade since `body.init` is long gone
+   by then. */
+body.init #background-wrapper {
     transition: none;
 }
 
@@ -123,13 +200,13 @@ body.init #background-media .background-image {
     opacity: var(--texture-opacity);
     background-image:
         repeating-linear-gradient(
-            45deg,
-            var(--texture-color) 25%,
-            transparent 25%,
-            transparent 75%,
-            var(--texture-color) 75%,
-            var(--texture-color)
-        ),
+        45deg,
+        var(--texture-color) 25%,
+        transparent 25%,
+        transparent 75%,
+        var(--texture-color) 75%,
+        var(--texture-color)
+    ),
         repeating-linear-gradient(
         45deg,
         var(--texture-color) 25%,
@@ -146,13 +223,13 @@ body.init #background-media .background-image {
     opacity: var(--texture-opacity);
     background-image:
         linear-gradient(
-            30deg,
-            var(--texture-color) 12%,
-            transparent 12.5%,
-            transparent 87%,
-            var(--texture-color) 87.5%,
-            var(--texture-color)
-        ),
+        30deg,
+        var(--texture-color) 12%,
+        transparent 12.5%,
+        transparent 87%,
+        var(--texture-color) 87.5%,
+        var(--texture-color)
+    ),
         linear-gradient(
         150deg,
         var(--texture-color) 12%,

--- a/src/styles/interface/error.css
+++ b/src/styles/interface/error.css
@@ -21,6 +21,14 @@
     z-index: 1;
 }
 
+/* Potato mode: text is always white here too, so bump opacity of the
+   same dark base color instead of relying on blur for contrast. */
+body.potato #error {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(0 0 0 / 0.75);
+}
+
 #error pre {
     width: calc(100% - 32px);
     overflow: hidden;

--- a/src/styles/interface/popup.css
+++ b/src/styles/interface/popup.css
@@ -33,6 +33,21 @@
     color: rgb(var(--font-on-blur-color));
 }
 
+/* Potato mode: text here is always white (--font-on-blur-color, it sits
+   over the wallpaper), so the fallback needs to stay dark regardless of
+   the light/dark theme -- a themed color like --color-param would go
+   white-on-white in light mode. */
+body.potato #popup_text,
+body.potato #popup_buttons a {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(0 0 0 / 0.55);
+}
+
+body.potato #popup_buttons a:hover {
+    background-color: rgb(0 0 0 / 0.7);
+}
+
 #popup_buttons {
     display: flex;
     flex-direction: column;

--- a/src/styles/interface/showsettings.css
+++ b/src/styles/interface/showsettings.css
@@ -52,6 +52,12 @@
     border: 1px solid rgb(255 255 255 / 0.075);
 }
 
+body.potato #show-settings.shown button {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgb(90 90 90 / 0.7);
+}
+
 #show-settings.shown button:hover {
     opacity: 1;
     background-color: rgb(102 102 102 / 0.4);

--- a/src/styles/settings/backgrounds.css
+++ b/src/styles/settings/backgrounds.css
@@ -56,6 +56,64 @@
     padding-block: 5px;
 }
 
+.upload-error {
+    display: none;
+    margin-top: 5px;
+    padding: 8px 12px;
+    font-size: 12px;
+    line-height: 1.4;
+    color: rgb(var(--danger-color));
+    background-color: rgb(var(--danger-color) / 0.12);
+    border: 1px solid rgb(var(--danger-color) / 0.4);
+    border-radius: 8px;
+}
+
+.upload-error.shown {
+    display: block;
+}
+
+/* Shown while addLocalBackgrounds() is compressing/decoding a batch, so a
+   large or multi-file upload reads as "working" instead of "hung". */
+.upload-progress {
+    display: none;
+    margin-top: 5px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background-color: var(--color-input);
+}
+
+.upload-progress.shown {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+#local-upload-progress-bar {
+    position: relative;
+    flex-shrink: 0;
+    width: 80px;
+    height: 6px;
+    border-radius: 4px;
+    overflow: hidden;
+    background-color: rgb(var(--accent-color) / 0.2);
+}
+
+#local-upload-progress-bar::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    width: var(--upload-progress-percent, 0%);
+    background-color: rgb(var(--accent-color));
+    border-radius: 4px;
+    transition: width 0.2s ease;
+}
+
+#local-upload-progress-text {
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--color-areas-text);
+}
+
 .thumbnail {
     position: relative;
     height: calc(230px / var(--thumbnails-columns));
@@ -213,4 +271,25 @@
     border-color: rgb(var(--color-green));
     background-size: 13px 13px;
     background-image: url('../../assets/labels/check.svg');
+}
+
+/* Background effect overlay (fireflies/rain, layered on top of the real
+   background -- see backgrounds/index.ts) -- a small button-group picker
+   instead of a plain <select>, since there are only two effects (plus
+   "None") and this is meant to feel like a fun little feature to pick
+   between, not just another dropdown buried in the list. Lives inside the
+   Texture overlay section in settings.html since both are optional layers
+   on top of the actual background. */
+#effect-buttons {
+    gap: 0.5em;
+    flex-wrap: wrap;
+}
+
+.effect-button {
+    flex: 1 1 auto;
+}
+
+.effect-button.selected {
+    color: white;
+    background-color: rgb(var(--accent-color));
 }

--- a/src/styles/settings/dropdowns.css
+++ b/src/styles/settings/dropdowns.css
@@ -181,8 +181,12 @@
     max-height: 60px;
 }
 
+/* <!> 245px was enough for just the texture picker + its own sub-options;
+   the Effect buttons (None/Fireflies/Cozy rain) now live inside this same
+   section (see settings.html), so the budget needs room for their
+   hr + label + button row too. */
 .all .as_texture {
-    max-height: 245px;
+    max-height: 345px;
 }
 
 .all .as_fadein {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -40,6 +40,7 @@
 @import './features/main.css';
 @import './features/searchbar.css';
 @import './features/notes.css';
+@import './features/scribble.css';
 @import './features/links.css';
 @import './features/quotes.css';
 @import './features/pomodoro.css';

--- a/src/types/local.ts
+++ b/src/types/local.ts
@@ -30,6 +30,12 @@ export interface Local {
     // Online
     syncStorage?: Sync
 
+    // Scribble pad (device-local: window position/size + drawing strokes,
+    // separate from `Notes`/`sync.notes` and from `sync.scribble`'s text)
+    scribblePosition?: { x: number; y: number }
+    scribbleSize?: { width: number; height: number }
+    scribbleDrawing?: string
+
     // Links
     [key: `x-icon-${string}`]: string
 }

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -35,6 +35,7 @@ export interface Sync {
         night: string
     }
     notes?: Notes
+    scribble?: Scribble
     hide?: Hide
     dark: 'auto' | 'system' | 'enable' | 'disable'
     dateformat: 'auto' | 'eu' | 'us' | 'cn'
@@ -74,6 +75,13 @@ export interface Hide {
 
 export interface Backgrounds {
     type: 'files' | 'urls' | 'images' | 'videos' | 'color'
+    /** Which animated "effect" overlay (if any) to layer on top of the
+     *  actual background above, independent of `type`. Each non-'none'
+     *  value ships as a self-contained html+js pair under
+     *  `src/assets/effects/` and is rendered via a sandboxed, non-interactive,
+     *  transparent iframe -- see `applyEffectBackground` in
+     *  `backgrounds/index.ts`. */
+    effect: 'none' | 'firefly' | 'rain'
     frequency: Frequency
     fadein: number
     bright: number
@@ -172,6 +180,22 @@ export interface Notes {
     width?: number
     background?: string
     opacity?: number
+}
+
+/**
+ * A small floating, draggable scribble pad -- separate from `Notes`.
+ * `text` (markdown) lives here because it's small; the freehand
+ * drawing strokes and on-screen position are bulkier/per-device and
+ * live in `Local` (`scribbleDrawing`, `scribblePosition`) instead.
+ *
+ * Markdown text and the doodle canvas are always both visible, stacked
+ * on top of each other -- `draw` just decides which layer currently
+ * receives pointer input (typing vs. scribbling), not which is shown.
+ */
+export interface Scribble {
+    on: boolean
+    draw: boolean
+    text?: string
 }
 
 export interface Quotes {

--- a/tasks/build.ts
+++ b/tasks/build.ts
@@ -220,6 +220,9 @@ function assets(platform: Platform): void {
     copyDir(`${source}/interface`, `${target}/interface`)
     copyDir(`${source}/labels`, `${target}/labels`)
     copyDir(`${source}/sounds`, `${target}/sounds`)
+    // Background "effects" (firefly/rain) -- self-contained html+js pairs
+    // loaded via <iframe src>, not bundled by esbuild.
+    copyDir(`${source}/effects`, `${target}/effects`)
 }
 
 function manifests(platform: Platform): void {


### PR DESCRIPTION
This started as a wallpaper upload fix but turned into a pretty deep pass on the upload pipeline and background rendering, so figured id just lump it all into one. Everything below was found and fixed by actually testing against a real freshly installed extension, not just reading the code. A few of these bugs only showed up once i started poking at it for real (ﾉ´ヮ`)ﾉ*:･ﾟ

## Upload pipeline bugs

* `filelist[i]` / `newids[i]` used the same index but `newids` skipped duplicate files while `filelist` didnt, so a dupe in a batch couldve shifted every id after it and saved a file's data under the WRONG id. data corruption basically. rebuilt this as one `{file, id}[]` array so theres no seperate index to desync
* `getLoadedVideo` had no timeout and no error listener, so a corrupt file or weird codec meant the upload would just sit there forever
* black video thumbnails from a dumb hardcoded `setTimeout(300ms)`, now it seeks to a frame and waits for the actual `seeked` event instead
* one bad file in a batch used to kill the WHOLE batch silently (single try/catch wrapping everything). now every file gets its own try/catch so one broken upload doesnt nuke the rest
* `canvas.toBlob()` returning null was getting cast straight to Blob and crashing deeper in the pipeline with a completely useless error
* no file type validation at all, dropping a `.pdf` or whatever used to just fail silently somewhere deep in the compression code
* `localFilesCacheControl` had zero error handling around cache reads, and CacheStorage can just get evicted by the browser whenever it feels like it (storage pressure, private browsing, etc), so this used to just break
* fixed 2 stale-timer bugs where a scheduled cleanup (from switching bg type or a crossfade) could fire AFTER a new background was applied and just delete it. reproduced this one concretely, its a real race and not just theoretical nonsense
* `storage.local` wasnt applying defaults on a fresh profile (unlike `storage.sync`), so uploading a background on a BRAND new install threw immediately. this alone probably explains most of the "upload just does nothing" reports

added a proper error banner in settings so failures actually show up now instead of vanishing into a `console.info`

## Rendering perf

* background images were decoding on the main thread at first paint - kinda was surprised actually, which is what caused the freeze/flash on every bg switch. now awaits `img.decode()` off main thread before the element even touches the DOM
* found a real event ordering race while fixing that: the decode fallback path needs its load/error listeners attached BEFORE `src` is set or it can miss an event that already fired and hang forever
* preloading only waited for fetch before, not decode, so the "instant" swap wasnt actually instant. fixed... fixed-ish i hope, patched it kinda rushed.
* first tab after install used to have this awkward black screen before the bg fades in, made the very first reveal instant instead - not sure if the fade in by default was wanted behaviour, my fade in was set to 0 and I still had fade in on new tabs on the image coming in, then no fading when the image switches on the same tab - either way, the fade in was like 9 fps? normal fade in afterwards is quite smooth, not too sure about that. 

## Potato mode + other stuff

* potato mode (low power device detection) had a coverage gap around `backdrop-filter` that let it slip through
* video/blob object URLs were leaking on every background switch, never getting revoked
* did a sweep across settings/notes/quotes/searchbar/contextmenu for unhandled promise rejections, fixed what i found
* weather requests used to just fail with no fallback, silently
* added upload progress UI + moved compression off the main thread (I added the progress UI for a reason, like yk how images get HUGE, mine was like 400mb and I got bloody frustrated, thought Bonjourr was frozen while uploading, but no, just processing - added this simple bar for my own sanity tbh, sorry)

## testing

ran `deno check` / `lint` / `fmt` / `test` / `build` clean - stuff the agent.md said - which funnily enough, I had to read to get an idea onn how to test, plus a bunch of actual playwright runs against the real built unpacked extension (not a DOM stub yep) to catch stuff like the race conditions above, cause a lotta these bugs only show up under real timing and not just from reading the source. I mean, it's tiny bugs, right, but it's been showing up on my laptop because of it's lagginess and i just kinda weirdly noticed weird hitches here and there?

Tried not to touch anything unrelated, tried to keep this scoped to actual bugs + perf even tho the diff ended up kinda big just from how many small things were broken. Mostly just perf stuff, since I was going insane with little hiccups and stutters I kept seeing.

## oh also I made a lil scribble pad

not really part of the fix, was just messing around. saw another extension had this lil doodle/notes thing and ppl were drawing like tiny smiley faces on their new tab page n stuff and i thought that was cute, so i threw together a small floating widget for it, markdown notes + freehand doodle, off by default and as a setting button so it doesnt get in anyones way. genuinely just rando stuff i was doing on the side beside actual bug patches, easy to rip out if it's a bloat widget - I didn't integrate it with other stuff, can just be yoinked out.