### PR TITLE
fix: preserve updated Unsplash search queries

### DIFF
--- a/src/scripts/features/backgrounds/index.ts
+++ b/src/scripts/features/backgrounds/index.ts
@@ -1,5 +1,4 @@
 import { applyUrls, getUrlsAsCollection, initUrlsEditor, urlsCacheControl } from './urls.ts'
-import { handleBackgroundActions, initBackgroundActionsEvents } from '../contextmenu.ts'
 import { toggleCredits, updateCredits } from './credits.ts'
 import { TEXTURE_RANGES } from './textures.ts'
 import { PROVIDERS } from './providers.ts'
@@ -62,6 +61,14 @@ let fadeinTimeout: ReturnType<typeof setTimeout>
 
 const formBackgroundUserColl = networkForm('f_background-user-coll')
 const formBackgroundUserSearch = networkForm('f_background-user-search')
+
+function handleBackgroundActions(backgrounds: Backgrounds): void {
+    void import('../contextmenu.ts').then((module) => module.handleBackgroundActions(backgrounds))
+}
+
+function initBackgroundActionsEvents(): void {
+    void import('../contextmenu.ts').then((module) => module.initBackgroundActionsEvents())
+}
 
 export function backgroundsInit(sync: Sync, local: Local, init?: true): void {
     if (init) {
@@ -289,7 +296,9 @@ export async function backgroundUpdate(update: BackgroundUpdate): Promise<void> 
 
         local.backgroundCollections[collectionName] = []
         data.backgrounds.queries[collectionName] = query
-        storage.sync.set({ backgrounds: data.backgrounds })
+        await storage.sync.update('backgrounds', (backgrounds) => {
+            backgrounds.queries[collectionName] = query
+        })
 
         // 2. Handle empty query
 
@@ -315,22 +324,12 @@ export async function backgroundUpdate(update: BackgroundUpdate): Promise<void> 
 }
 
 export async function filtersUpdate({ blur, bright, fadein, texture }: Partial<Backgrounds>): Promise<void> {
-    const data = await storage.sync.get('backgrounds')
-
-    if (blur !== undefined) {
-        data.backgrounds.blur = blur
-    }
-    if (bright !== undefined) {
-        data.backgrounds.bright = bright
-    }
-    if (fadein !== undefined) {
-        data.backgrounds.fadein = fadein
-    }
-    if (texture !== undefined) {
-        data.backgrounds.texture = texture
-    }
-
-    storage.sync.set({ backgrounds: data.backgrounds })
+    await storage.sync.update('backgrounds', (backgrounds) => {
+        if (blur !== undefined) backgrounds.blur = blur
+        if (bright !== undefined) backgrounds.bright = bright
+        if (fadein !== undefined) backgrounds.fadein = fadein
+        if (texture !== undefined) backgrounds.texture = texture
+    })
 }
 
 async function solidUpdate(value: string): Promise<void> {

--- a/src/scripts/storage.ts
+++ b/src/scripts/storage.ts
@@ -22,12 +22,14 @@ interface Storage {
     sync: {
         get: (key?: string | string[]) => Promise<Sync>
         set: (val: Partial<Sync>) => Promise<void>
+        update: <Key extends keyof Sync>(key: Key, update: (value: Sync[Key]) => void | Promise<void>) => Promise<void>
         remove: (key: string) => void
         clear: () => Promise<void>
     }
     local: {
         get: (key?: keyof Local | (keyof Local)[]) => Promise<Local>
-        set: (val: Partial<Local>) => void
+        set: (val: Partial<Local>) => Promise<void>
+        update: <Key extends keyof Local>(key: Key, fn: (value: Local[Key]) => void | Promise<void>) => Promise<void>
         remove: (key: keyof Local) => void
         clear: () => void
     }
@@ -44,12 +46,14 @@ export const storage: Storage = {
     sync: {
         get: syncGet,
         set: syncSet,
+        update: syncUpdate,
         remove: syncRemove,
         clear: syncClear,
     },
     local: {
         get: localGet,
         set: localSet,
+        update: localUpdate,
         remove: localRemove,
         clear: localClear,
     },
@@ -57,6 +61,9 @@ export const storage: Storage = {
     clearall: clearall,
     type: storageTypeFn(),
 }
+
+let syncUpdateQueue = Promise.resolve()
+let localUpdateQueue = Promise.resolve()
 
 //	Storage type
 
@@ -78,6 +85,7 @@ function storageTypeFn(): StorageTypeReturn {
             return 'webext-local'
         }
 
+        type = 'webext-sync'
         return type
     }
 
@@ -120,12 +128,12 @@ async function syncGet(key?: string | string[]): Promise<Sync> {
     }
 }
 
-async function syncSet(keyval: Record<string, unknown>, fn = () => {}): Promise<void> {
+async function syncSet(keyval: Record<string, unknown>): Promise<void> {
     // console.log('sync set', JSON.stringify(keyval))
 
     switch (storage.type.get()) {
         case 'webext-sync': {
-            chrome.storage.sync.set(keyval, fn)
+            await chrome.storage.sync.set(keyval)
             return
         }
 
@@ -136,7 +144,7 @@ async function syncSet(keyval: Record<string, unknown>, fn = () => {}): Promise<
                 ...keyval,
             }
 
-            chrome.storage.local.set({ syncStorage: data }, fn)
+            await chrome.storage.local.set({ syncStorage: data })
             return
         }
 
@@ -158,6 +166,19 @@ async function syncSet(keyval: Record<string, unknown>, fn = () => {}): Promise<
 
         default:
     }
+}
+
+function syncUpdate<Key extends keyof Sync>(
+    key: Key,
+    update: (value: Sync[Key]) => void | Promise<void>,
+): Promise<void> {
+    const operation = syncUpdateQueue.then(async () => {
+        const data = await syncGet(key as string)
+        await update(data[key])
+        await syncSet({ [key]: data[key] })
+    })
+    syncUpdateQueue = operation.catch(() => {})
+    return operation
 }
 
 async function syncRemove(key: string): Promise<void> {
@@ -211,13 +232,13 @@ async function syncClear(): Promise<void> {
 
 //	Local data
 
-function localSet(value: Record<string, unknown>): void {
+async function localSet(value: Record<string, unknown>): Promise<void> {
     // console.log('local set', JSON.stringify(value))
 
     switch (storage.type.get()) {
         case 'webext-sync':
         case 'webext-local': {
-            chrome.storage.local.set(value)
+            await chrome.storage.local.set(value)
             return
         }
 
@@ -232,6 +253,19 @@ function localSet(value: Record<string, unknown>): void {
             return
         }
     }
+}
+
+function localUpdate<Key extends keyof Local>(
+    key: Key,
+    update: (value: Local[Key]) => void | Promise<void>,
+): Promise<void> {
+    const operation = localUpdateQueue.then(async () => {
+        const data = await localGet(key as string)
+        await update(data[key])
+        await localSet({ [key]: data[key] })
+    })
+    localUpdateQueue = operation.catch(() => {})
+    return operation
 }
 
 async function localGet(keys?: string | string[]): Promise<Local> {

--- a/tests/features/backgrounds.test.ts
+++ b/tests/features/backgrounds.test.ts
@@ -1,0 +1,111 @@
+import { assertEquals } from '@std/assert'
+import '../init.ts'
+
+import { LOCAL_DEFAULT, SYNC_DEFAULT } from '../../src/scripts/defaults.ts'
+import { loadCallbacks } from '../../src/scripts/utils/onsettingsload.ts'
+
+type StoredData = Record<string, unknown>
+
+document.body.innerHTML = `
+    <main id="interface"></main>
+    <dialog id="contextmenu"></dialog>
+    <div id="background-wrapper">
+        <div id="background-media"><div></div></div>
+        <div id="background-texture"></div>
+    </div>
+    <form id="f_background-user-coll"><input /><button></button><small></small></form>
+    <form id="f_background-user-search"><input /><button></button><small></small></form>
+`
+
+const syncData = structuredClone(SYNC_DEFAULT) as unknown as StoredData
+const localData = structuredClone(LOCAL_DEFAULT) as unknown as StoredData
+const firstReadStarted = deferred<void>()
+const releaseFirstRead = deferred<void>()
+let syncGetCount = 0
+
+const syncArea = {
+    async get(keys?: string | string[] | null): Promise<StoredData> {
+        syncGetCount += 1
+        if (syncGetCount === 1) {
+            firstReadStarted.resolve()
+            await releaseFirstRead.promise
+        }
+
+        if (typeof keys === 'string') {
+            return { [keys]: structuredClone(syncData[keys]) }
+        }
+
+        return structuredClone(syncData)
+    },
+    async set(items: StoredData): Promise<void> {
+        Object.assign(syncData, structuredClone(items))
+    },
+} as unknown as chrome.storage.StorageArea
+
+const localArea = {
+    async get(keys?: string | string[] | null): Promise<StoredData> {
+        if (typeof keys === 'string') {
+            return { [keys]: structuredClone(localData[keys]) }
+        }
+
+        return structuredClone(localData)
+    },
+    async set(items: StoredData): Promise<void> {
+        Object.assign(localData, structuredClone(items))
+    },
+} as unknown as chrome.storage.StorageArea
+
+Reflect.set(globalThis, 'chrome', { storage: { sync: syncArea, local: localArea } })
+globalThis.startupStorage = {
+    sync: structuredClone(SYNC_DEFAULT),
+    local: structuredClone(LOCAL_DEFAULT),
+}
+
+const { storage } = await import('../../src/scripts/storage.ts')
+const { backgroundUpdate, filtersUpdate } = await import('../../src/scripts/features/backgrounds/index.ts')
+storage.type.init()
+loadCallbacks()
+
+Deno.test({
+    name: 'A delayed background update preserves a newly emptied Unsplash query',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+        const backgrounds = syncData.backgrounds as typeof SYNC_DEFAULT.backgrounds
+        const local = localData as unknown as typeof LOCAL_DEFAULT
+        backgrounds.images = 'unsplash-images-search'
+        backgrounds.queries['unsplash-images-search'] = 'old query'
+        local.backgroundCollections['unsplash-images-search'] = [{
+            format: 'image',
+            page: '',
+            username: '',
+            urls: { full: 'https://example.com/image.jpg', small: 'https://example.com/image.jpg' },
+        }]
+
+        const olderUpdate = filtersUpdate({ bright: 0.35 })
+        await firstReadStarted.promise
+
+        const form = document.getElementById('f_background-user-search') as HTMLFormElement
+        const input = form.querySelector('input') as HTMLInputElement
+        input.value = ''
+        const submit = new SubmitEvent('submit')
+        Object.defineProperty(submit, 'target', { value: form })
+
+        const queryUpdate = backgroundUpdate({ query: submit })
+        await Promise.resolve()
+        releaseFirstRead.resolve()
+        await Promise.all([olderUpdate, queryUpdate])
+
+        const reloaded = await storage.sync.get('backgrounds')
+        const reloadedLocal = await storage.local.get('backgroundCollections')
+        assertEquals(reloaded.backgrounds.bright, 0.35)
+        assertEquals(reloaded.backgrounds.queries['unsplash-images-search'], '')
+        assertEquals(reloadedLocal.backgroundCollections['unsplash-images-search'], [])
+    },
+})
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+    let resolve = (_value: T | PromiseLike<T>): void => {}
+    const promise = new Promise<T>((promiseResolve) => resolve = promiseResolve)
+    return { promise, resolve }
+}

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,0 +1,178 @@
+import { assertEquals, assertRejects } from '@std/assert'
+import './init.ts'
+
+import { LOCAL_DEFAULT, SYNC_DEFAULT } from '../src/scripts/defaults.ts'
+import { storage } from '../src/scripts/storage.ts'
+
+type StoredData = Record<string, unknown>
+
+interface MockStorageArea {
+    area: chrome.storage.StorageArea
+    data: StoredData
+    rejectNextGet: (message: string) => void
+    rejectNextSet: (message: string) => void
+}
+
+Deno.test({
+    name: 'Queued sync updates preserve the latest background state',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+        const sync = createStorageArea(SYNC_DEFAULT as unknown as StoredData)
+        const local = createStorageArea(LOCAL_DEFAULT as unknown as StoredData)
+        useChromeStorage(sync.area, local.area)
+        globalThis.startupStorage = {
+            sync: structuredClone(SYNC_DEFAULT),
+            local: structuredClone(LOCAL_DEFAULT),
+        }
+        storage.type.init()
+
+        const firstUpdateStarted = deferred<void>()
+        const releaseFirstUpdate = deferred<void>()
+        const olderUpdate = storage.sync.update('backgrounds', async (backgrounds) => {
+            firstUpdateStarted.resolve()
+            await releaseFirstUpdate.promise
+            backgrounds.bright = 0.4
+        })
+
+        await firstUpdateStarted.promise
+
+        const queryUpdate = storage.sync.update('backgrounds', (backgrounds) => {
+            backgrounds.queries['unsplash-images-search'] = 'snowy mountains'
+        })
+
+        releaseFirstUpdate.resolve()
+        await Promise.all([olderUpdate, queryUpdate])
+
+        const reloaded = await storage.sync.get('backgrounds')
+        assertEquals(reloaded.backgrounds.bright, 0.4)
+        assertEquals(reloaded.backgrounds.queries['unsplash-images-search'], 'snowy mountains')
+    },
+})
+
+Deno.test({
+    name: 'Queued sync updates use disabled-sync storage',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+        const sync = createStorageArea()
+        const local = createStorageArea({
+            ...structuredClone(LOCAL_DEFAULT),
+            syncStorage: structuredClone(SYNC_DEFAULT),
+        })
+        useChromeStorage(sync.area, local.area)
+        globalThis.startupStorage = {
+            local: local.data as unknown as typeof LOCAL_DEFAULT,
+        }
+        storage.type.init()
+
+        await Promise.all([
+            storage.sync.update('backgrounds', (backgrounds) => {
+                backgrounds.mute = false
+            }),
+            storage.sync.update('backgrounds', (backgrounds) => {
+                backgrounds.queries['unsplash-images-search'] = 'desert'
+            }),
+        ])
+
+        const reloaded = await storage.sync.get('backgrounds')
+        assertEquals(reloaded.backgrounds.mute, false)
+        assertEquals(reloaded.backgrounds.queries['unsplash-images-search'], 'desert')
+    },
+})
+
+Deno.test({
+    name: 'Rejected queued sync updates do not block later updates',
+    sanitizeOps: false,
+    sanitizeResources: false,
+    fn: async () => {
+        const sync = createStorageArea(SYNC_DEFAULT as unknown as StoredData)
+        const local = createStorageArea(LOCAL_DEFAULT as unknown as StoredData)
+        useChromeStorage(sync.area, local.area)
+        globalThis.startupStorage = {
+            sync: structuredClone(SYNC_DEFAULT),
+            local: structuredClone(LOCAL_DEFAULT),
+        }
+        storage.type.init()
+
+        sync.rejectNextGet('read failed')
+        await assertRejects(
+            () => storage.sync.update('backgrounds', (backgrounds) => {
+                backgrounds.blur = 1
+            }),
+            Error,
+            'read failed',
+        )
+
+        sync.rejectNextSet('write failed')
+        await assertRejects(
+            () => storage.sync.update('backgrounds', (backgrounds) => {
+                backgrounds.blur = 2
+            }),
+            Error,
+            'write failed',
+        )
+
+        await storage.sync.update('backgrounds', (backgrounds) => {
+            backgrounds.blur = 3
+        })
+
+        const reloaded = await storage.sync.get('backgrounds')
+        assertEquals(reloaded.backgrounds.blur, 3)
+    },
+})
+
+function createStorageArea(initial: StoredData = {}): MockStorageArea {
+    const data = structuredClone(initial)
+    let getError: Error | undefined
+    let setError: Error | undefined
+
+    const area = {
+        async get(keys?: string | string[] | null): Promise<StoredData> {
+            if (getError) {
+                const error = getError
+                getError = undefined
+                throw error
+            }
+
+            if (typeof keys === 'string') {
+                return keys in data ? { [keys]: structuredClone(data[keys]) } : {}
+            }
+            if (Array.isArray(keys)) {
+                return Object.fromEntries(keys.filter((key) => key in data).map((key) => [key, structuredClone(data[key])]))
+            }
+
+            return structuredClone(data)
+        },
+        async set(items: StoredData): Promise<void> {
+            if (setError) {
+                const error = setError
+                setError = undefined
+                throw error
+            }
+
+            Object.assign(data, structuredClone(items))
+        },
+    } as unknown as chrome.storage.StorageArea
+
+    return {
+        area,
+        data,
+        rejectNextGet(message: string): void {
+            getError = new Error(message)
+        },
+        rejectNextSet(message: string): void {
+            setError = new Error(message)
+        },
+    }
+}
+
+function useChromeStorage(sync: chrome.storage.StorageArea, local: chrome.storage.StorageArea): void {
+    Reflect.set(globalThis, 'chrome', { storage: { sync, local } })
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+    let resolve = (_value: T | PromiseLike<T>): void => {}
+    const promise = new Promise<T>((promiseResolve) => resolve = promiseResolve)
+    return { promise, resolve }
+}


### PR DESCRIPTION
Add a storage-level queued update operation for read-modify-write changes so a mutation is applied to the latest persisted value and completes before the next mutation for the same storage area begins. Without it, a user can save a new Unsplash custom search query, continue browsing, and later find that the setting has reverted to an older query, sometimes while images still reflect the newer value. The race is in Bonjourr's own read-modify-write rather than in any one browser: `storage.sync` / `storage.local` give no atomicity across a separate read and write in any engine. Scheduling differences only change how often two updates overlap, which is why it was reported from Firefox.

Save a new value for `backgrounds.queries['unsplash-images-search']` and verify a subsequent reload returns that exact value; Start two queued mutations from the same initial `backgrounds` state, let the older operation finish after the query change, and verify the latest query and the unrelated background property are both preserved.

Closes #908

